### PR TITLE
Make the QNetworkReader and Writer Inherent from BinaryReader and Writer

### DIFF
--- a/QSB/QuantumSync/Events/QuantumShuffleMessage.cs
+++ b/QSB/QuantumSync/Events/QuantumShuffleMessage.cs
@@ -12,7 +12,7 @@ namespace QSB.QuantumSync.Events
 		public override void Deserialize(QNetworkReader reader)
 		{
 			base.Deserialize(reader);
-			IndexArray = Array.ConvertAll(reader.ReadBytesAndSize(), Convert.ToInt32);
+			IndexArray = Array.ConvertAll(reader.ReadByteArray(), Convert.ToInt32);
 		}
 
 		public override void Serialize(QNetworkWriter writer)

--- a/QuantumUNET/Components/QNetworkAnimator.cs
+++ b/QuantumUNET/Components/QNetworkAnimator.cs
@@ -207,7 +207,7 @@ namespace QuantumUNET.Components
 				if (!autoSend || GetParameterAutoSend(index))
 				{
 					var parameter = m_Animator.parameters[index];
-					if (reader.Length == reader.Position)
+					if (reader.BaseStream.Length == reader.BaseStream.Position)
 					{
 						return;
 					}

--- a/QuantumUNET/Messages/QAddPlayerMessage.cs
+++ b/QuantumUNET/Messages/QAddPlayerMessage.cs
@@ -17,7 +17,7 @@ namespace QuantumUNET.Messages
 		public override void Deserialize(QNetworkReader reader)
 		{
 			playerControllerId = reader.ReadInt16();
-			msgData = reader.ReadBytesAndSize();
+			msgData = reader.ReadByteArray();
 			msgSize = msgData?.Length ?? 0;
 		}
 	}

--- a/QuantumUNET/Messages/QAnimationMessage.cs
+++ b/QuantumUNET/Messages/QAnimationMessage.cs
@@ -23,7 +23,7 @@ namespace QuantumUNET.Messages
 			netId = reader.ReadNetworkId();
 			stateHash = (int)reader.ReadPackedUInt32();
 			normalizedTime = reader.ReadSingle();
-			parameters = reader.ReadBytesAndSize();
+			parameters = reader.ReadByteArray();
 		}
 	}
 }

--- a/QuantumUNET/Messages/QAnimationParametersMessage.cs
+++ b/QuantumUNET/Messages/QAnimationParametersMessage.cs
@@ -11,7 +11,7 @@ namespace QuantumUNET.Messages
 		public override void Deserialize(QNetworkReader reader)
 		{
 			netId = reader.ReadNetworkId();
-			parameters = reader.ReadBytesAndSize();
+			parameters = reader.ReadByteArray();
 		}
 
 		public override void Serialize(QNetworkWriter writer)

--- a/QuantumUNET/Messages/QObjectSpawnMessage.cs
+++ b/QuantumUNET/Messages/QObjectSpawnMessage.cs
@@ -26,8 +26,8 @@ namespace QuantumUNET.Messages
 			NetId = reader.ReadNetworkId();
 			assetId = reader.ReadNetworkHash128();
 			Position = reader.ReadVector3();
-			Payload = reader.ReadBytesAndSize();
-			if (reader.Length - reader.Position >= 16U)
+			Payload = reader.ReadByteArray();
+			if (reader.BaseStream.Length - reader.BaseStream.Position >= 16U)
 			{
 				Rotation = reader.ReadQuaternion();
 			}

--- a/QuantumUNET/Messages/QObjectSpawnSceneMessage.cs
+++ b/QuantumUNET/Messages/QObjectSpawnSceneMessage.cs
@@ -24,7 +24,7 @@ namespace QuantumUNET.Messages
 			NetId = reader.ReadNetworkId();
 			SceneId = reader.ReadSceneId();
 			Position = reader.ReadVector3();
-			Payload = reader.ReadBytesAndSize();
+			Payload = reader.ReadByteArray();
 		}
 	}
 }

--- a/QuantumUNET/QNetworkConnection.cs
+++ b/QuantumUNET/QNetworkConnection.cs
@@ -323,7 +323,7 @@ namespace QuantumUNET
 
 		protected void HandleReader(QNetworkReader reader, int receivedSize, int channelId)
 		{
-			while (reader.Position < receivedSize)
+			while (reader.BaseStream.Position < receivedSize)
 			{
 				var num = reader.ReadUInt16();
 				var num2 = reader.ReadInt16();

--- a/QuantumUNET/Transport/QChannelBuffer.cs
+++ b/QuantumUNET/Transport/QChannelBuffer.cs
@@ -189,7 +189,7 @@ namespace QuantumUNET.Transport
 					_readingFragment = true;
 				}
 
-				var array = reader.ReadBytesAndSize();
+				var array = reader.ReadByteArray();
 				_fragmentBuffer.WriteBytes(array, (ushort)array.Length);
 				result = false;
 			}


### PR DESCRIPTION
QNetworkReader and Writer have a lot of methods that already exist in BinaryReader and in BinaryWriter, so I decided to make both classes inherent from them while trying to keep the same custom methods where possible. I haven't tested it, but I'm confident that it would work. 