### PR TITLE
Build Fixes

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <GameDir>D:\EpicGames\OuterWilds</GameDir>
+    <OwmlDir>$(AppData)\OuterWildsModManager\OWML</OwmlDir>
+  </PropertyGroup>
+</Project>

--- a/QSB/QSB.csproj
+++ b/QSB/QSB.csproj
@@ -435,7 +435,7 @@ copy /y "$(ProjectDir)\default-config.json" "$(OwmlDir)\Mods\$(ProjectName)"
 copy /y "$(SolutionDir)\AssetBundles" "$(OwmlDir)\Mods\$(ProjectName)\assets"
 copy /y "$(ProjectDir)\manifest.json" "$(OwmlDir)\Mods\$(ProjectName)"
 
-"$(SolutionDir)\QNetWeaver\bin\Debug\QNetWeaver.exe" "$(GameDir)\OuterWilds_Data\Managed\UnityEngine.CoreModule.dll" "$(OwmlDir)\Mods\$(ProjectName)\QuantumUNET.dll" "$(ProjectDir)\lib\UnityEngine.Networking.dll"  "$(SolutionDir)\WeavedFiles" "$(TargetPath)"
+"$(SolutionDir)\QNetWeaver\bin\$(Configuration)\QNetWeaver.exe" "$(GameDir)\OuterWilds_Data\Managed\UnityEngine.CoreModule.dll" "$(OwmlDir)\Mods\$(ProjectName)\QuantumUNET.dll" "$(ProjectDir)\lib\UnityEngine.Networking.dll"  "$(SolutionDir)\WeavedFiles" "$(TargetPath)"
 
 copy /y "$(SolutionDir)\WeavedFiles\QSB.dll" "$(OwmlDir)\Mods\$(ProjectName)"
 

--- a/QSB/QSB.csproj
+++ b/QSB/QSB.csproj
@@ -13,6 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -22,7 +23,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/QSB/QSB.csproj.user
+++ b/QSB/QSB.csproj.user
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <GameDir>D:\EpicGames\OuterWilds</GameDir>
-    <OwmlDir>C:\Users\Henry\AppData\Roaming\OuterWildsModManager\OWML</OwmlDir>
-    <ProjectView>ShowAllFiles</ProjectView>
-  </PropertyGroup>
-</Project>

--- a/QSBTests/QSBTests.csproj.user
+++ b/QSBTests/QSBTests.csproj.user
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <GameDir>D:\SteamLibrary\steamapps\common\Outer Wilds</GameDir>
-    <OwmlDir>C:\Users\Henry\AppData\Roaming\OuterWildsModManager\OWML</OwmlDir>
-    <ProjectView>ShowAllFiles</ProjectView>
-  </PropertyGroup>
-</Project>

--- a/QuantumUNET/QuantumUNET.csproj.user
+++ b/QuantumUNET/QuantumUNET.csproj.user
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <GameDir>D:\EpicGames\OuterWilds</GameDir>
-    <OwmlDir>C:\Users\Henry\AppData\Roaming\OuterWildsModManager\OWML</OwmlDir>
-    <ProjectView>ShowAllFiles</ProjectView>
-  </PropertyGroup>
-</Project>


### PR DESCRIPTION
- AllowUnsafeBlocks was only being set for Debug builds, now it is set regardless of configuration.
- qnetweaver was being called from the debug path only, now it will be called from a path determined by the active configuration.
- Moved solution properties (OwmlDir and GameDir) to a single Directory.Build.targets file as having to modify it in three separate locations was inconvenient.