### PR TITLE
Github Actions builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,21 @@
+name: Build
+
+on:
+  push:
+    branches: [dev]
+  workflow_dispatch:
+
+jobs:
+
+  build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: "5.0.x"
+    - run: dotnet build -c Release
+    - uses: actions/upload-artifact@v2
+      with:
+        name: QSB-prerelease
+        path: .\QSB\Bin\Release


### PR DESCRIPTION
Whenever a commit is pushed to the dev branch the Github CI will run build.yaml which checks out the latest dev branch, builds it, and uploads it as an artifact to the workflow run.

See this as an example: https://github.com/PhantomGamers/quantum-space-buddies/actions/runs/1509698080

The build files are shown at the bottom under artifacts as "QSB-prerelease"

Builds can also be ran manually on any branch from https://github.com/misternebula/quantum-space-buddies/actions/workflows/build.yaml

**This requires #365 to be merged before it will work**
