### PR TITLE
Avoid duplicate builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    if: (github.event_name == 'pull_request' && github.event.pull_request.merged != 'true') || github.event_name == 'push'
     runs-on: windows-latest
     steps:
 


### PR DESCRIPTION
- If the build is triggered by a pull request, don't build if the pull request was merged (the push event will do it)