### PR TITLE
build.yaml: better duplicate build avoidance

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,8 +7,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  pre_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          paths_ignore: '["**/README.md"]'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
   build:
-    if: (github.event_name == 'pull_request' && github.event.pull_request.merged != 'true') || github.event_name == 'push'
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: windows-latest
     steps:
 


### PR DESCRIPTION
uses https://github.com/marketplace/actions/skip-duplicate-actions to avoid duplicate builds

this should be merged into master as well