### PR TITLE
QuantumUNET.csproj: disable obsolete warnings

### DIFF
--- a/QuantumUNET/QuantumUNET.csproj
+++ b/QuantumUNET/QuantumUNET.csproj
@@ -4,6 +4,7 @@
     <Product>QuantumUNET</Product>
     <ProjectGuid>{C8C53004-1508-4F86-A419-4292C188DC2A}</ProjectGuid>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
+    <NoWarn>1701;1702;0618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>


### PR DESCRIPTION
the obsolete methods will never be removed so let's not flood build logs with them