### PR TITLE
Unique ObjectId

### DIFF
--- a/QSB/Anglerfish/WorldObjects/QSBAngler.cs
+++ b/QSB/Anglerfish/WorldObjects/QSBAngler.cs
@@ -21,7 +21,9 @@ namespace QSB.Anglerfish.WorldObjects
 
 			if (QSBCore.IsHost)
 			{
-				QNetworkServer.Spawn(Object.Instantiate(QSBNetworkManager.Instance.AnglerPrefab));
+				var transformSync = Object.Instantiate(QSBNetworkManager.Instance.AnglerPrefab).GetComponent<AnglerTransformSync>();
+				transformSync.ObjectId = ObjectId;
+				QNetworkServer.Spawn(transformSync.gameObject);
 			}
 
 			StartDelayedReady();

--- a/QSB/Animation/NPC/Patches/CharacterAnimationPatches.cs
+++ b/QSB/Animation/NPC/Patches/CharacterAnimationPatches.cs
@@ -153,7 +153,7 @@ namespace QSB.Animation.NPC.Patches
 				return true;
 			}
 
-			var id = QSBWorldSync.GetIdFromTypeSubset(ownerOfThis);
+			var id = ownerOfThis.ObjectId;
 			QSBEventManager.FireEvent(EventNames.QSBNpcAnimEvent, AnimationEvent.StartConversation, id);
 			return true;
 		}
@@ -169,7 +169,7 @@ namespace QSB.Animation.NPC.Patches
 				return true;
 			}
 
-			var id = QSBWorldSync.GetIdFromTypeSubset(ownerOfThis);
+			var id = ownerOfThis.ObjectId;
 			QSBEventManager.FireEvent(EventNames.QSBNpcAnimEvent, AnimationEvent.EndConversation, id);
 			return true;
 		}

--- a/QSB/Animation/NPC/WorldObjects/INpcAnimController.cs
+++ b/QSB/Animation/NPC/WorldObjects/INpcAnimController.cs
@@ -1,6 +1,8 @@
-﻿namespace QSB.Animation.NPC.WorldObjects
+﻿using QSB.WorldSync;
+
+namespace QSB.Animation.NPC.WorldObjects
 {
-	public interface INpcAnimController
+	public interface INpcAnimController : IWorldObject
 	{
 		CharacterDialogueTree GetDialogueTree();
 		void StartConversation();

--- a/QSB/ElevatorSync/Patches/ElevatorPatches.cs
+++ b/QSB/ElevatorSync/Patches/ElevatorPatches.cs
@@ -17,7 +17,7 @@ namespace QSB.ElevatorSync.Patches
 		public static void Elevator_StartLift(Elevator __instance)
 		{
 			var isGoingUp = __instance.GetValue<bool>("_goingToTheEnd");
-			var id = QSBWorldSync.GetIdFromUnity<QSBElevator>(__instance);
+			var id = QSBWorldSync.GetWorldFromUnity<QSBElevator>(__instance).ObjectId;
 			QSBEventManager.FireEvent(EventNames.QSBStartLift, id, isGoingUp);
 		}
 	}

--- a/QSB/ItemSync/Patches/ItemPatches.cs
+++ b/QSB/ItemSync/Patches/ItemPatches.cs
@@ -20,7 +20,7 @@ namespace QSB.ItemSync.Patches
 		[HarmonyPatch(typeof(ItemTool), nameof(ItemTool.MoveItemToCarrySocket))]
 		public static bool ItemTool_MoveItemToCarrySocket(OWItem item)
 		{
-			var qsbObj = (IQSBOWItem)QSBWorldSync.GetWorldFromUnity(item);
+			var qsbObj = QSBWorldSync.GetWorldFromUnity<IQSBOWItem>(item);
 			var itemId = qsbObj.ObjectId;
 			QSBPlayerManager.LocalPlayer.HeldItem = qsbObj;
 			QSBEventManager.FireEvent(EventNames.QSBMoveToCarry, itemId);
@@ -31,8 +31,8 @@ namespace QSB.ItemSync.Patches
 		[HarmonyPatch(typeof(ItemTool), nameof(ItemTool.SocketItem))]
 		public static bool ItemTool_SocketItem(OWItem ____heldItem, OWItemSocket socket)
 		{
-			var qsbObj = (IQSBOWItem)QSBWorldSync.GetWorldFromUnity(____heldItem);
-			var socketId = QSBWorldSync.GetWorldFromUnity(socket).ObjectId;
+			var qsbObj = QSBWorldSync.GetWorldFromUnity<IQSBOWItem>(____heldItem);
+			var socketId = QSBWorldSync.GetWorldFromUnity<IQSBOWItemSocket>(socket).ObjectId;
 			var itemId = qsbObj.ObjectId;
 			QSBPlayerManager.LocalPlayer.HeldItem = null;
 			QSBEventManager.FireEvent(EventNames.QSBSocketItem, socketId, itemId, SocketEventType.Socket);
@@ -43,9 +43,9 @@ namespace QSB.ItemSync.Patches
 		[HarmonyPatch(typeof(ItemTool), nameof(ItemTool.StartUnsocketItem))]
 		public static bool ItemTool_StartUnsocketItem(OWItemSocket socket)
 		{
-			var item = (IQSBOWItem)QSBWorldSync.GetWorldFromUnity(socket.GetSocketedItem());
+			var item = QSBWorldSync.GetWorldFromUnity<IQSBOWItem>(socket.GetSocketedItem());
 			QSBPlayerManager.LocalPlayer.HeldItem = item;
-			var socketId = QSBWorldSync.GetWorldFromUnity(socket).ObjectId;
+			var socketId = QSBWorldSync.GetWorldFromUnity<IQSBOWItemSocket>(socket).ObjectId;
 			QSBEventManager.FireEvent(EventNames.QSBSocketItem, socketId, 0, SocketEventType.StartUnsocket);
 			return true;
 		}
@@ -54,7 +54,7 @@ namespace QSB.ItemSync.Patches
 		[HarmonyPatch(typeof(ItemTool), nameof(ItemTool.CompleteUnsocketItem))]
 		public static bool ItemTool_CompleteUnsocketItem(OWItem ____heldItem)
 		{
-			var itemId = QSBWorldSync.GetWorldFromUnity(____heldItem).ObjectId;
+			var itemId = QSBWorldSync.GetWorldFromUnity<IQSBOWItem>(____heldItem).ObjectId;
 			QSBEventManager.FireEvent(EventNames.QSBSocketItem, 0, itemId, SocketEventType.CompleteUnsocket);
 			return true;
 		}
@@ -90,7 +90,7 @@ namespace QSB.ItemSync.Patches
 			var parent = (customDropTarget == null)
 				? targetRigidbody.transform
 				: customDropTarget.GetItemDropTargetTransform(hit.collider.gameObject);
-			var objectId = QSBWorldSync.GetWorldFromUnity(____heldItem).ObjectId;
+			var objectId = QSBWorldSync.GetWorldFromUnity<IQSBOWItem>(____heldItem).ObjectId;
 			____heldItem.DropItem(hit.point, hit.normal, parent, sector, customDropTarget);
 			____heldItem = null;
 			QSBPlayerManager.LocalPlayer.HeldItem = null;

--- a/QSB/ItemSync/Patches/ItemPatches.cs
+++ b/QSB/ItemSync/Patches/ItemPatches.cs
@@ -21,7 +21,7 @@ namespace QSB.ItemSync.Patches
 		public static bool ItemTool_MoveItemToCarrySocket(OWItem item)
 		{
 			var qsbObj = (IQSBOWItem)QSBWorldSync.GetWorldFromUnity(item);
-			var itemId = QSBWorldSync.GetIdFromTypeSubset(qsbObj);
+			var itemId = qsbObj.ObjectId;
 			QSBPlayerManager.LocalPlayer.HeldItem = qsbObj;
 			QSBEventManager.FireEvent(EventNames.QSBMoveToCarry, itemId);
 			return true;
@@ -32,8 +32,8 @@ namespace QSB.ItemSync.Patches
 		public static bool ItemTool_SocketItem(OWItem ____heldItem, OWItemSocket socket)
 		{
 			var qsbObj = (IQSBOWItem)QSBWorldSync.GetWorldFromUnity(____heldItem);
-			var socketId = QSBWorldSync.GetIdFromTypeSubset((IQSBOWItemSocket)QSBWorldSync.GetWorldFromUnity(socket));
-			var itemId = QSBWorldSync.GetIdFromTypeSubset(qsbObj);
+			var socketId = QSBWorldSync.GetWorldFromUnity(socket).ObjectId;
+			var itemId = qsbObj.ObjectId;
 			QSBPlayerManager.LocalPlayer.HeldItem = null;
 			QSBEventManager.FireEvent(EventNames.QSBSocketItem, socketId, itemId, SocketEventType.Socket);
 			return true;
@@ -45,7 +45,7 @@ namespace QSB.ItemSync.Patches
 		{
 			var item = (IQSBOWItem)QSBWorldSync.GetWorldFromUnity(socket.GetSocketedItem());
 			QSBPlayerManager.LocalPlayer.HeldItem = item;
-			var socketId = QSBWorldSync.GetIdFromTypeSubset((IQSBOWItemSocket)QSBWorldSync.GetWorldFromUnity(socket));
+			var socketId = QSBWorldSync.GetWorldFromUnity(socket).ObjectId;
 			QSBEventManager.FireEvent(EventNames.QSBSocketItem, socketId, 0, SocketEventType.StartUnsocket);
 			return true;
 		}
@@ -54,7 +54,7 @@ namespace QSB.ItemSync.Patches
 		[HarmonyPatch(typeof(ItemTool), nameof(ItemTool.CompleteUnsocketItem))]
 		public static bool ItemTool_CompleteUnsocketItem(OWItem ____heldItem)
 		{
-			var itemId = QSBWorldSync.GetIdFromTypeSubset((IQSBOWItem)QSBWorldSync.GetWorldFromUnity(____heldItem));
+			var itemId = QSBWorldSync.GetWorldFromUnity(____heldItem).ObjectId;
 			QSBEventManager.FireEvent(EventNames.QSBSocketItem, 0, itemId, SocketEventType.CompleteUnsocket);
 			return true;
 		}
@@ -90,7 +90,7 @@ namespace QSB.ItemSync.Patches
 			var parent = (customDropTarget == null)
 				? targetRigidbody.transform
 				: customDropTarget.GetItemDropTargetTransform(hit.collider.gameObject);
-			var objectId = QSBWorldSync.GetIdFromTypeSubset((IQSBOWItem)QSBWorldSync.GetWorldFromUnity(____heldItem));
+			var objectId = QSBWorldSync.GetWorldFromUnity(____heldItem).ObjectId;
 			____heldItem.DropItem(hit.point, hit.normal, parent, sector, customDropTarget);
 			____heldItem = null;
 			QSBPlayerManager.LocalPlayer.HeldItem = null;

--- a/QSB/ItemSync/WorldObjects/Items/IQSBOWItem.cs
+++ b/QSB/ItemSync/WorldObjects/Items/IQSBOWItem.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace QSB.ItemSync.WorldObjects.Items
 {
-	public interface IQSBOWItem : IWorldObjectTypeSubset
+	public interface IQSBOWItem : IWorldObject
 	{
 		ItemType GetItemType();
 		void SetColliderActivation(bool active);

--- a/QSB/ItemSync/WorldObjects/Items/QSBOWItem.cs
+++ b/QSB/ItemSync/WorldObjects/Items/QSBOWItem.cs
@@ -46,7 +46,7 @@ namespace QSB.ItemSync.WorldObjects.Items
 
 				if (InitialParent?.GetComponent<OWItemSocket>() != null)
 				{
-					var qsbObj = (IQSBOWItemSocket)QSBWorldSync.GetWorldFromUnity(InitialParent.GetComponent<OWItemSocket>());
+					var qsbObj = QSBWorldSync.GetWorldFromUnity<IQSBOWItemSocket>(InitialParent.GetComponent<OWItemSocket>());
 					InitialSocket = qsbObj;
 				}
 			});

--- a/QSB/ItemSync/WorldObjects/Sockets/IQSBOWItemSocket.cs
+++ b/QSB/ItemSync/WorldObjects/Sockets/IQSBOWItemSocket.cs
@@ -3,7 +3,7 @@ using QSB.WorldSync;
 
 namespace QSB.ItemSync.WorldObjects.Sockets
 {
-	public interface IQSBOWItemSocket : IWorldObjectTypeSubset
+	public interface IQSBOWItemSocket : IWorldObject
 	{
 		bool AcceptsItem(IQSBOWItem item);
 		bool IsSocketOccupied();

--- a/QSB/ItemSync/WorldObjects/Sockets/QSBOWItemDoubleSocket.cs
+++ b/QSB/ItemSync/WorldObjects/Sockets/QSBOWItemDoubleSocket.cs
@@ -19,9 +19,9 @@ namespace QSB.ItemSync.WorldObjects.Sockets
 			=> AttachedObject.IsSocketOccupied();
 
 		public virtual bool PlaceIntoSocket(IQSBOWItem item)
-			=> AttachedObject.PlaceIntoSocket((OWItem)(item as IWorldObject).ReturnObject());
+			=> AttachedObject.PlaceIntoSocket((OWItem)item.ReturnObject());
 
 		public virtual IQSBOWItem RemoveFromSocket()
-			=> (IQSBOWItem)QSBWorldSync.GetWorldFromUnity(AttachedObject.RemoveFromSocket());
+			=> QSBWorldSync.GetWorldFromUnity<IQSBOWItem>(AttachedObject.RemoveFromSocket());
 	}
 }

--- a/QSB/ItemSync/WorldObjects/Sockets/QSBOWItemSocket.cs
+++ b/QSB/ItemSync/WorldObjects/Sockets/QSBOWItemSocket.cs
@@ -19,9 +19,9 @@ namespace QSB.ItemSync.WorldObjects.Sockets
 			=> AttachedObject.IsSocketOccupied();
 
 		public virtual bool PlaceIntoSocket(IQSBOWItem item)
-			=> AttachedObject.PlaceIntoSocket((OWItem)(item as IWorldObject).ReturnObject());
+			=> AttachedObject.PlaceIntoSocket((OWItem)item.ReturnObject());
 
 		public virtual IQSBOWItem RemoveFromSocket()
-			=> (IQSBOWItem)QSBWorldSync.GetWorldFromUnity(AttachedObject.RemoveFromSocket());
+			=> QSBWorldSync.GetWorldFromUnity<IQSBOWItem>(AttachedObject.RemoveFromSocket());
 	}
 }

--- a/QSB/JellyfishSync/TransformSync/JellyfishTransformSync.cs
+++ b/QSB/JellyfishSync/TransformSync/JellyfishTransformSync.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using QSB.JellyfishSync.WorldObjects;
+﻿using QSB.JellyfishSync.WorldObjects;
 using QSB.Syncs;
 using QSB.Syncs.Unsectored.Rigidbodies;
 using QSB.Utility;
@@ -14,29 +13,17 @@ namespace QSB.JellyfishSync.TransformSync
 		public override bool IsReady => WorldObjectManager.AllObjectsAdded;
 		public override bool UseInterpolation => false;
 
+		public int ObjectId = -1;
 		private QSBJellyfish _qsbJellyfish;
-		private static readonly List<JellyfishTransformSync> _instances = new();
 
 		protected override OWRigidbody GetRigidbody()
 			=> _qsbJellyfish.AttachedObject._jellyfishBody;
-
-		public override void Start()
-		{
-			_instances.Add(this);
-			base.Start();
-		}
-
-		protected override void OnDestroy()
-		{
-			_instances.Remove(this);
-			base.OnDestroy();
-		}
 
 		public override float GetNetworkSendInterval() => 10;
 
 		protected override void Init()
 		{
-			_qsbJellyfish = QSBWorldSync.GetWorldFromId<QSBJellyfish>(_instances.IndexOf(this));
+			_qsbJellyfish = QSBWorldSync.GetWorldFromId<QSBJellyfish>(ObjectId);
 			_qsbJellyfish.TransformSync = this;
 
 			base.Init();
@@ -46,6 +33,11 @@ namespace QSB.JellyfishSync.TransformSync
 		public override void SerializeTransform(QNetworkWriter writer, bool initialState)
 		{
 			base.SerializeTransform(writer, initialState);
+
+			if (initialState)
+			{
+				writer.Write(ObjectId);
+			}
 
 			if (!WorldObjectManager.AllObjectsReady)
 			{
@@ -62,6 +54,11 @@ namespace QSB.JellyfishSync.TransformSync
 		public override void DeserializeTransform(QNetworkReader reader, bool initialState)
 		{
 			base.DeserializeTransform(reader, initialState);
+
+			if (initialState)
+			{
+				ObjectId = reader.ReadInt32();
+			}
 
 			if (!WorldObjectManager.AllObjectsReady || HasAuthority)
 			{

--- a/QSB/JellyfishSync/WorldObjects/QSBJellyfish.cs
+++ b/QSB/JellyfishSync/WorldObjects/QSBJellyfish.cs
@@ -19,7 +19,9 @@ namespace QSB.JellyfishSync.WorldObjects
 
 			if (QSBCore.IsHost)
 			{
-				QNetworkServer.Spawn(Object.Instantiate(QSBNetworkManager.Instance.JellyfishPrefab));
+				var transformSync = Object.Instantiate(QSBNetworkManager.Instance.JellyfishPrefab).GetComponent<JellyfishTransformSync>();
+				transformSync.ObjectId = ObjectId;
+				QNetworkServer.Spawn(transformSync.gameObject);
 			}
 
 			StartDelayedReady();

--- a/QSB/Player/Events/RequestStateResyncEvent.cs
+++ b/QSB/Player/Events/RequestStateResyncEvent.cs
@@ -83,11 +83,8 @@ namespace QSB.Player.Events
 					=> QSBEventManager.FireEvent(EventNames.QSBTextTranslated, NomaiTextType.VesselComputer, vesselComputer.ObjectId, id));
 			}
 
-			var list = QSBWorldSync.GetWorldObjects<IQSBQuantumObject>().ToList();
-			for (var i = 0; i < list.Count; i++)
-			{
-				QSBEventManager.FireEvent(EventNames.QSBQuantumAuthority, i, list[i].ControllingPlayer);
-			}
+			QSBWorldSync.GetWorldObjects<IQSBQuantumObject>().ForEach(x
+				=> QSBEventManager.FireEvent(EventNames.QSBQuantumAuthority, QSBWorldSync.GetIdFromTypeSubset(x), x.ControllingPlayer));
 
 			QSBWorldSync.GetWorldObjects<QSBCampfire>().ForEach(campfire
 				=> QSBEventManager.FireEvent(EventNames.QSBCampfireState, campfire.ObjectId, campfire.GetState()));

--- a/QSB/Player/Events/RequestStateResyncEvent.cs
+++ b/QSB/Player/Events/RequestStateResyncEvent.cs
@@ -84,7 +84,7 @@ namespace QSB.Player.Events
 			}
 
 			QSBWorldSync.GetWorldObjects<IQSBQuantumObject>().ForEach(x
-				=> QSBEventManager.FireEvent(EventNames.QSBQuantumAuthority, QSBWorldSync.GetIdFromTypeSubset(x), x.ControllingPlayer));
+				=> QSBEventManager.FireEvent(EventNames.QSBQuantumAuthority, x.ObjectId, x.ControllingPlayer));
 
 			QSBWorldSync.GetWorldObjects<QSBCampfire>().ForEach(campfire
 				=> QSBEventManager.FireEvent(EventNames.QSBCampfireState, campfire.ObjectId, campfire.GetState()));

--- a/QSB/Player/PlayerEntanglementWatcher.cs
+++ b/QSB/Player/PlayerEntanglementWatcher.cs
@@ -26,8 +26,8 @@ namespace QSB.Player
 			var collidingQuantumObject = controller.GetValue<QuantumObject>("_collidingQuantumObject");
 			if (_previousCollidingQuantumObject != collidingQuantumObject)
 			{
-				var objectIndex = (collidingQuantumObject != null)
-					? QSBWorldSync.GetWorldFromUnity(collidingQuantumObject).ObjectId
+				var objectIndex = collidingQuantumObject != null
+					? QSBWorldSync.GetWorldFromUnity<IQSBQuantumObject>(collidingQuantumObject).ObjectId
 					: -1;
 
 				QSBEventManager.FireEvent(

--- a/QSB/Player/PlayerEntanglementWatcher.cs
+++ b/QSB/Player/PlayerEntanglementWatcher.cs
@@ -27,7 +27,7 @@ namespace QSB.Player
 			if (_previousCollidingQuantumObject != collidingQuantumObject)
 			{
 				var objectIndex = (collidingQuantumObject != null)
-					? QSBWorldSync.GetIdFromTypeSubset((IQSBQuantumObject)QSBWorldSync.GetWorldFromUnity(collidingQuantumObject))
+					? QSBWorldSync.GetWorldFromUnity(collidingQuantumObject).ObjectId
 					: -1;
 
 				QSBEventManager.FireEvent(

--- a/QSB/QSBNetworkManager.cs
+++ b/QSB/QSBNetworkManager.cs
@@ -253,7 +253,6 @@ namespace QSB
 
 		private void RemoveWorldObjects()
 		{
-			QSBWorldSync.RemoveWorldObjects<IWorldObjectTypeSubset>();
 			QSBWorldSync.RemoveWorldObjects<IWorldObject>();
 			foreach (var platform in QSBWorldSync.GetUnityObjects<CustomNomaiRemoteCameraPlatform>())
 			{

--- a/QSB/QuantumSync/QuantumManager.cs
+++ b/QSB/QuantumSync/QuantumManager.cs
@@ -151,7 +151,7 @@ namespace QSB.QuantumSync
 				return Enumerable.Empty<PlayerInfo>();
 			}
 
-			var worldObj = (IQSBQuantumObject)QSBWorldSync.GetWorldFromUnity(obj);
+			var worldObj = QSBWorldSync.GetWorldFromUnity<IQSBQuantumObject>(obj);
 			return QSBPlayerManager.PlayerList.Where(x => x.EntangledObject == worldObj);
 		}
 	}

--- a/QSB/QuantumSync/WorldObjects/IQSBQuantumObject.cs
+++ b/QSB/QuantumSync/WorldObjects/IQSBQuantumObject.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace QSB.QuantumSync
 {
-	public interface IQSBQuantumObject : IWorldObjectTypeSubset
+	public interface IQSBQuantumObject : IWorldObject
 	{
 		uint ControllingPlayer { get; set; }
 		bool IsEnabled { get; set; }

--- a/QSB/QuantumSync/WorldObjects/QSBQuantumObject.cs
+++ b/QSB/QuantumSync/WorldObjects/QSBQuantumObject.cs
@@ -171,7 +171,7 @@ namespace QSB.QuantumSync.WorldObjects
 				return;
 			}
 
-			var id = QSBWorldSync.GetIdFromTypeSubset<IQSBQuantumObject>(this);
+			var id = ObjectId;
 			// no one is controlling this object right now, request authority
 			QSBEventManager.FireEvent(EventNames.QSBQuantumAuthority, id, QSBPlayerManager.LocalPlayerId);
 		}
@@ -200,7 +200,7 @@ namespace QSB.QuantumSync.WorldObjects
 				return;
 			}
 
-			var id = QSBWorldSync.GetIdFromTypeSubset<IQSBQuantumObject>(this);
+			var id = ObjectId;
 			// send event to other players that we're releasing authority
 			QSBEventManager.FireEvent(EventNames.QSBQuantumAuthority, id, 0u);
 		}

--- a/QSB/Tools/TranslatorTool/TranslationSync/Patches/SpiralPatches.cs
+++ b/QSB/Tools/TranslatorTool/TranslationSync/Patches/SpiralPatches.cs
@@ -23,7 +23,7 @@ namespace QSB.Tools.TranslatorTool.TranslationSync.Patches
 			QSBEventManager.FireEvent(
 					EventNames.QSBTextTranslated,
 					NomaiTextType.WallText,
-					QSBWorldSync.GetIdFromUnity<QSBWallText>(__instance),
+					QSBWorldSync.GetWorldFromUnity<QSBWallText>(__instance).ObjectId,
 					id);
 			return true;
 		}
@@ -40,7 +40,7 @@ namespace QSB.Tools.TranslatorTool.TranslationSync.Patches
 			QSBEventManager.FireEvent(
 					EventNames.QSBTextTranslated,
 					NomaiTextType.Computer,
-					QSBWorldSync.GetIdFromUnity<QSBComputer>(__instance),
+					QSBWorldSync.GetWorldFromUnity<QSBComputer>(__instance).ObjectId,
 					id);
 			return true;
 		}
@@ -57,7 +57,7 @@ namespace QSB.Tools.TranslatorTool.TranslationSync.Patches
 			QSBEventManager.FireEvent(
 					EventNames.QSBTextTranslated,
 					NomaiTextType.VesselComputer,
-					QSBWorldSync.GetIdFromUnity<QSBVesselComputer>(__instance),
+					QSBWorldSync.GetWorldFromUnity<QSBVesselComputer>(__instance).ObjectId,
 					id);
 			return true;
 		}

--- a/QSB/WorldSync/IWorldObjectTypeSubset.cs
+++ b/QSB/WorldSync/IWorldObjectTypeSubset.cs
@@ -1,4 +1,0 @@
-﻿namespace QSB.WorldSync
-{
-	public interface IWorldObjectTypeSubset { }
-}

--- a/QSB/WorldSync/QSBWorldSync.cs
+++ b/QSB/WorldSync/QSBWorldSync.cs
@@ -73,10 +73,6 @@ namespace QSB.WorldSync
 			return (TWorldObject)returnObject;
 		}
 
-		public static int GetIdFromUnity<TWorldObject>(MonoBehaviour unityObject)
-			where TWorldObject : IWorldObject
-			=> GetWorldFromUnity<TWorldObject>(unityObject).ObjectId;
-
 		public static void RemoveWorldObjects<TWorldObject>()
 			where TWorldObject : IWorldObject
 		{

--- a/QSB/WorldSync/QSBWorldSync.cs
+++ b/QSB/WorldSync/QSBWorldSync.cs
@@ -41,35 +41,6 @@ namespace QSB.WorldSync
 			return worldObject;
 		}
 
-		public static IWorldObject GetWorldFromUnity(MonoBehaviour unityObject)
-		{
-			if (unityObject == null)
-			{
-				DebugLog.ToConsole($"Error - Trying to run GetWorldFromUnity with a null unity object! TUnityObject:NULL, Stacktrace:\r\n{Environment.StackTrace}", MessageType.Error);
-				return default;
-			}
-
-			if (!QSBCore.IsInMultiplayer)
-			{
-				DebugLog.ToConsole($"Warning - Trying to run GetWorldFromUnity while not in multiplayer! TUnityObject:{unityObject.GetType().Name}, Stacktrace:\r\n{Environment.StackTrace}", MessageType.Warning);
-				return default;
-			}
-
-			if (!WorldObjectsToUnityObjects.TryGetValue(unityObject, out var returnObject))
-			{
-				DebugLog.ToConsole($"Error - WorldObjectsToUnityObjects does not contain \"{unityObject.name}\"! TUnityObject:{unityObject.GetType().Name}, Stacktrace:\r\n{Environment.StackTrace}", MessageType.Error);
-				return default;
-			}
-
-			if (returnObject == null)
-			{
-				DebugLog.ToConsole($"Error - World object for unity object {unityObject.name} is null! TUnityObject:{unityObject.GetType().Name}, Stacktrace:\r\n{Environment.StackTrace}", MessageType.Error);
-				return default;
-			}
-
-			return returnObject;
-		}
-
 		public static TWorldObject GetWorldFromUnity<TWorldObject>(MonoBehaviour unityObject)
 			where TWorldObject : IWorldObject
 		{

--- a/QSB/WorldSync/QSBWorldSync.cs
+++ b/QSB/WorldSync/QSBWorldSync.cs
@@ -16,6 +16,7 @@ namespace QSB.WorldSync
 		public static Dictionary<string, bool> DialogueConditions { get; } = new();
 		public static List<FactReveal> ShipLogFacts { get; } = new();
 
+		public static int NextObjectId;
 		private static readonly List<IWorldObject> WorldObjects = new();
 		private static readonly Dictionary<MonoBehaviour, IWorldObject> WorldObjectsToUnityObjects = new();
 
@@ -24,14 +25,20 @@ namespace QSB.WorldSync
 
 		public static TWorldObject GetWorldFromId<TWorldObject>(int id)
 		{
-			var worldObjects = GetWorldObjects<TWorldObject>().ToList();
-			if (id < 0 || id >= worldObjects.Count)
+			if (id < 0 || id >= WorldObjects.Count)
 			{
-				DebugLog.ToConsole($"Warning - Tried to find {typeof(TWorldObject).Name} id {id}. Count is {worldObjects.Count}.", MessageType.Warning);
+				DebugLog.ToConsole($"Warning - Tried to find world object id {id}. Count is {WorldObjects.Count}.", MessageType.Warning);
 				return default;
 			}
 
-			return worldObjects[id];
+			var iWorldObject = WorldObjects[id];
+			if (iWorldObject is not TWorldObject worldObject)
+			{
+				DebugLog.ToConsole($"Error - World object id {id} expected {typeof(TWorldObject).Name}, but got {iWorldObject.GetType().Name}.", MessageType.Error);
+				return default;
+			}
+
+			return worldObject;
 		}
 
 		public static IWorldObject GetWorldFromUnity(MonoBehaviour unityObject)
@@ -146,11 +153,11 @@ namespace QSB.WorldSync
 			RemoveWorldObjects<TWorldObject>();
 			var list = GetUnityObjects<TUnityObject>().ToList();
 			//DebugLog.DebugWrite($"{typeof(TWorldObject).Name} init : {list.Count} instances.", MessageType.Info);
-			for (var id = 0; id < list.Count; id++)
+			foreach (var unityObject in list)
 			{
 				var obj = CreateWorldObject<TWorldObject>();
-				obj.Init(list[id], id);
-				WorldObjectsToUnityObjects.Add(list[id], obj);
+				obj.Init(unityObject, NextObjectId++);
+				WorldObjectsToUnityObjects.Add(unityObject, obj);
 			}
 		}
 

--- a/QSB/WorldSync/QSBWorldSync.cs
+++ b/QSB/WorldSync/QSBWorldSync.cs
@@ -106,6 +106,8 @@ namespace QSB.WorldSync
 
 		public static int GetIdFromTypeSubset<TTypeSubset>(TTypeSubset typeSubset)
 		{
+			return ((IWorldObject)typeSubset).ObjectId;
+
 			var index = GetWorldObjects<TTypeSubset>().ToList().IndexOf(typeSubset);
 			if (index == -1)
 			{

--- a/QSB/WorldSync/QSBWorldSync.cs
+++ b/QSB/WorldSync/QSBWorldSync.cs
@@ -21,9 +21,11 @@ namespace QSB.WorldSync
 		private static readonly Dictionary<MonoBehaviour, IWorldObject> WorldObjectsToUnityObjects = new();
 
 		public static IEnumerable<TWorldObject> GetWorldObjects<TWorldObject>()
+			where TWorldObject : IWorldObject
 			=> WorldObjects.OfType<TWorldObject>();
 
 		public static TWorldObject GetWorldFromId<TWorldObject>(int id)
+			where TWorldObject : IWorldObject
 		{
 			if (id < 0 || id >= WorldObjects.Count)
 			{
@@ -76,6 +78,7 @@ namespace QSB.WorldSync
 			=> GetWorldFromUnity<TWorldObject>(unityObject).ObjectId;
 
 		public static void RemoveWorldObjects<TWorldObject>()
+			where TWorldObject : IWorldObject
 		{
 			if (WorldObjects.Count == 0)
 			{

--- a/QSB/WorldSync/QSBWorldSync.cs
+++ b/QSB/WorldSync/QSBWorldSync.cs
@@ -104,19 +104,6 @@ namespace QSB.WorldSync
 			where TWorldObject : IWorldObject
 			=> GetWorldFromUnity<TWorldObject>(unityObject).ObjectId;
 
-		public static int GetIdFromTypeSubset<TTypeSubset>(TTypeSubset typeSubset)
-		{
-			return ((IWorldObject)typeSubset).ObjectId;
-
-			var index = GetWorldObjects<TTypeSubset>().ToList().IndexOf(typeSubset);
-			if (index == -1)
-			{
-				DebugLog.ToConsole($"Warning - {((IWorldObject)typeSubset).Name} doesn't exist in list of {typeof(TTypeSubset).Name} !", MessageType.Warning);
-			}
-
-			return index;
-		}
-
 		public static void RemoveWorldObjects<TWorldObject>()
 		{
 			if (WorldObjects.Count == 0)

--- a/QSB/WorldSync/QSBWorldSync.cs
+++ b/QSB/WorldSync/QSBWorldSync.cs
@@ -140,7 +140,7 @@ namespace QSB.WorldSync
 				.Where(x => x.gameObject.scene.name != null);
 
 		public static void Init<TWorldObject, TUnityObject>()
-			where TWorldObject : WorldObject<TUnityObject>
+			where TWorldObject : WorldObject<TUnityObject>, new()
 			where TUnityObject : MonoBehaviour
 		{
 			RemoveWorldObjects<TWorldObject>();
@@ -155,15 +155,10 @@ namespace QSB.WorldSync
 		}
 
 		private static TWorldObject CreateWorldObject<TWorldObject>()
-			where TWorldObject : IWorldObject
+			where TWorldObject : IWorldObject, new()
 		{
-			var worldObject = (TWorldObject)Activator.CreateInstance(typeof(TWorldObject));
+			var worldObject = new TWorldObject();
 			WorldObjects.Add(worldObject);
-			if (worldObject == null)
-			{
-				// if this happens, god help you
-				DebugLog.ToConsole($"Error - CreateWorldObject is returning a null value! This is very bad!", MessageType.Error);
-			}
 
 			return worldObject;
 		}

--- a/QSB/WorldSync/WorldObjectManager.cs
+++ b/QSB/WorldSync/WorldObjectManager.cs
@@ -49,14 +49,14 @@ namespace QSB.WorldSync
 		{
 			if (!QSBNetworkManager.Instance.IsReady)
 			{
-				DebugLog.ToConsole($"Warning - Tried to rebuild WorldObjects when Network Manager not ready!", OWML.Common.MessageType.Warning);
+				DebugLog.ToConsole($"Warning - Tried to rebuild WorldObjects when Network Manager not ready!", MessageType.Warning);
 				QSBCore.UnityEvents.RunWhen(() => QSBNetworkManager.Instance.IsReady, () => Rebuild(scene));
 				return;
 			}
 
 			if (QSBPlayerManager.LocalPlayerId == uint.MaxValue)
 			{
-				DebugLog.ToConsole($"Warning - Tried to rebuild WorldObjects when LocalPlayer is not ready!", OWML.Common.MessageType.Warning);
+				DebugLog.ToConsole($"Warning - Tried to rebuild WorldObjects when LocalPlayer is not ready!", MessageType.Warning);
 				QSBCore.UnityEvents.RunWhen(() => QSBPlayerManager.LocalPlayerId != uint.MaxValue, () => Rebuild(scene));
 				return;
 			}
@@ -72,6 +72,7 @@ namespace QSB.WorldSync
 
 		private static void DoRebuild(OWScene scene)
 		{
+			QSBWorldSync.NextObjectId = 0;
 			_numManagersReadying = 0;
 			_numObjectsReadying = 0;
 			AllObjectsAdded = false;
@@ -85,7 +86,7 @@ namespace QSB.WorldSync
 				}
 				catch (Exception ex)
 				{
-					DebugLog.ToConsole($"Exception - Exception when trying to rebuild WorldObjects of manager {manager.GetType().Name} : {ex.Message} Stacktrace :\r\n{ex.StackTrace}", OWML.Common.MessageType.Error);
+					DebugLog.ToConsole($"Exception - Exception when trying to rebuild WorldObjects of manager {manager.GetType().Name} : {ex.Message} Stacktrace :\r\n{ex.StackTrace}", MessageType.Error);
 				}
 			}
 

--- a/QuantumUNET/Messages/QNetworkMessage.cs
+++ b/QuantumUNET/Messages/QNetworkMessage.cs
@@ -12,7 +12,7 @@ namespace QuantumUNET.Messages
 
 		public TMsg ReadMessage<TMsg>() where TMsg : QMessageBase, new()
 		{
-			var result = Activator.CreateInstance<TMsg>();
+			var result = new TMsg();
 			result.Deserialize(Reader);
 			return result;
 		}

--- a/QuantumUNET/Transport/QNetworkReader.cs
+++ b/QuantumUNET/Transport/QNetworkReader.cs
@@ -458,7 +458,7 @@ namespace QuantumUNET.Transport
 
 		public TMsg ReadMessage<TMsg>() where TMsg : QMessageBase, new()
 		{
-			var result = Activator.CreateInstance<TMsg>();
+			var result = new TMsg();
 			result.Deserialize(this);
 			return result;
 		}


### PR DESCRIPTION
turns GetWorldFromId into a single index lookup.
makes TypeSubset useless, since every worldobject will have a unique id.

NOTE: objectId create order now matters, rather than just unity object order in relation to the same type of other objects. everything still work fine, though.
there is a way away this in case things it is worrying, where you sort by the unityobject name and further by the index into GetUnityObjects, but that would take a fair bit of refactoring.

this is a low priority. things work fine without it