### PR TITLE
InitializeAssemblies hotfix

### DIFF
--- a/QSB/QSBCore.cs
+++ b/QSB/QSBCore.cs
@@ -1,5 +1,4 @@
-﻿using HarmonyLib;
-using Mirror;
+﻿using Mirror;
 using OWML.Common;
 using OWML.ModHelper;
 using QSB.Menus;
@@ -124,30 +123,21 @@ namespace QSB
 			DebugLog.DebugWrite("Running RuntimeInitializeOnLoad methods for our assemblies", MessageType.Info);
 			foreach (var path in Directory.EnumerateFiles(Helper.Manifest.ModFolderPath, "*.dll"))
 			{
-				try
+				var assembly = Assembly.LoadFile(path);
+				if (Path.GetFileNameWithoutExtension(path) == "ProxyScripts")
 				{
-					var assembly = Assembly.LoadFile(path);
-					DebugLog.DebugWrite(assembly.ToString());
-					assembly
-						.GetTypes()
-						.SelectMany(x => x.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly))
-						.Where(x => x.IsDefined(typeof(RuntimeInitializeOnLoadMethodAttribute)))
-						.ForEach(x => x.Invoke(null, null));
+					continue;
 				}
-				catch (ReflectionTypeLoadException e)
-				{
-				DebugLog.ToConsole($"InitializeAssemblies for {path}:", MessageType.Warning);
-				DebugLog.ToConsole(e.ToString(), MessageType.Warning);
-				DebugLog.ToConsole(e.LoaderExceptions.Join(x => "\t" + x, "\n"), MessageType.Warning);
-				}
-				catch (Exception e)
-				{
-				DebugLog.ToConsole($"InitializeAssemblies for {path}:", MessageType.Warning);
-				DebugLog.ToConsole(e.ToString(), MessageType.Warning);
-				}
+
+				DebugLog.DebugWrite(assembly.ToString());
+				assembly
+					.GetTypes()
+					.SelectMany(x => x.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly))
+					.Where(x => x.IsDefined(typeof(RuntimeInitializeOnLoadMethodAttribute)))
+					.ForEach(x => x.Invoke(null, null));
 			}
 
-			DebugLog.DebugWrite($"Assemblies initialized", MessageType.Success);
+			DebugLog.DebugWrite("Assemblies initialized", MessageType.Success);
 		}
 
 		public override void Configure(IModConfig config) => DefaultServerIP = config.GetSettingsValue<string>("defaultServerIP");

--- a/QSB/QSBCore.cs
+++ b/QSB/QSBCore.cs
@@ -136,12 +136,14 @@ namespace QSB
 				}
 				catch (ReflectionTypeLoadException e)
 				{
-					DebugLog.DebugWrite(e.ToString(), MessageType.Error);
-					DebugLog.DebugWrite(e.LoaderExceptions.Join(x => "\t" + x, "\n"), MessageType.Error);
+				DebugLog.ToConsole($"InitializeAssemblies for {path}:", MessageType.Warning);
+				DebugLog.ToConsole(e.ToString(), MessageType.Warning);
+				DebugLog.ToConsole(e.LoaderExceptions.Join(x => "\t" + x, "\n"), MessageType.Warning);
 				}
 				catch (Exception e)
 				{
-					DebugLog.DebugWrite(e.ToString(), MessageType.Error);
+				DebugLog.ToConsole($"InitializeAssemblies for {path}:", MessageType.Warning);
+				DebugLog.ToConsole(e.ToString(), MessageType.Warning);
 				}
 			}
 

--- a/QSB/manifest.json
+++ b/QSB/manifest.json
@@ -7,7 +7,7 @@
 		"body": "- Disable *all* other mods. (Can heavily affect performance)\n- Make sure you are not running any other network-intensive applications.\n- Make sure you have forwarded/opened the correct ports. (See the GitHub readme.)"
 	},
 	"uniqueName": "Raicuparta.QuantumSpaceBuddies",
-	"version": "0.17.0",
+	"version": "0.17.1",
 	"owmlVersion": "2.3.2",
 	"dependencies": [ "_nebula.MenuFramework" ]
 }


### PR DESCRIPTION
ignore ProxyScripts because that references Assembly-CSharp and tends to try to find nonexistent types.
It doesn't need to be "initialized" anyways since it has no RuntimeInitializeOnLoad methods