### PR TITLE
Open ports are no longer required.

### DIFF
--- a/QSB/manifest.json
+++ b/QSB/manifest.json
@@ -4,7 +4,7 @@
 	"name": "Quantum Space Buddies",
 	"warning": {
 		"title": "Follow these steps before playing multiplayer :",
-		"body": "- Disable *all* other mods. (Can heavily affect performance)\n- Make sure you are not running any other network-intensive applications.\n- Make sure you have forwarded/opened the correct ports. (See the GitHub readme.)"
+		"body": "- Disable *all* other mods. (Can heavily affect performance)\n- Make sure you are not running any other network-intensive applications."
 	},
 	"uniqueName": "Raicuparta.QuantumSpaceBuddies",
 	"version": "0.17.1",


### PR DESCRIPTION
I think that should be taken out of the warning.