### PR TITLE
More Sound Sync

### DIFF
--- a/QSB/Animation/Player/AnimationSync.cs
+++ b/QSB/Animation/Player/AnimationSync.cs
@@ -93,6 +93,7 @@ public class AnimationSync : PlayerSyncObject
 		SetSuitState(QSBSceneManager.CurrentScene == OWScene.EyeOfTheUniverse);
 		InitAccelerationSync();
 		ThrusterManager.CreateRemotePlayerVFX(Player);
+		ThrusterManager.CreateRemotePlayerSFX(Player);
 
 		Delay.RunWhen(() => Player.CameraBody != null,
 			() => body.GetComponent<PlayerHeadRotationSync>().Init(Player.CameraBody.transform));

--- a/QSB/Animation/Player/Messages/PlayerSuitMessage.cs
+++ b/QSB/Animation/Player/Messages/PlayerSuitMessage.cs
@@ -37,6 +37,15 @@ public class PlayerSuitMessage : QSBMessage<bool>
 
 		var animator = player.AnimationSync;
 		animator.SetSuitState(Data);
+
+		if (player.SuitedUp)
+		{
+			player.AudioController.PlayWearSuit();
+		}
+		else
+		{
+			player.AudioController.PlayRemoveSuit();
+		}
 	}
 
 	public override void OnReceiveLocal()

--- a/QSB/Animation/Player/Thrusters/ThrusterManager.cs
+++ b/QSB/Animation/Player/Thrusters/ThrusterManager.cs
@@ -1,4 +1,5 @@
-﻿using QSB.Player;
+﻿using QSB.Audio;
+using QSB.Player;
 using UnityEngine;
 
 namespace QSB.Animation.Player.Thrusters;
@@ -12,6 +13,11 @@ internal static class ThrusterManager
 		InitWashController(newVfx.transform.Find("ThrusterWash").gameObject, player);
 		InitFlameControllers(newVfx, player);
 		InitParticleControllers(newVfx, player);
+	}
+
+	public static void CreateRemotePlayerSFX(PlayerInfo player)
+	{
+		player.Body.GetComponentInChildren<QSBJetpackThrusterAudio>(true)?.Init(player);
 	}
 
 	private static void InitFlameControllers(GameObject root, PlayerInfo player)

--- a/QSB/Audio/Messages/PlayerAudioControllerOneShotMessage.cs
+++ b/QSB/Audio/Messages/PlayerAudioControllerOneShotMessage.cs
@@ -1,0 +1,16 @@
+﻿using QSB.Messaging;
+using QSB.Player;
+using QSB.WorldSync;
+
+namespace QSB.Audio.Messages;
+
+
+public class PlayerAudioControllerOneShotMessage : QSBMessage<(AudioType audioType, uint userID)>
+{
+	public PlayerAudioControllerOneShotMessage(AudioType audioType, uint userID) : base((audioType, userID)) { }
+
+	public override bool ShouldReceive => QSBWorldSync.AllObjectsReady;
+
+	public override void OnReceiveRemote() =>
+		QSBPlayerManager.GetPlayer(Data.userID)?.AudioController?.PlayOneShot(Data.audioType);
+}

--- a/QSB/Audio/Messages/PlayerAudioControllerOneShotMessage.cs
+++ b/QSB/Audio/Messages/PlayerAudioControllerOneShotMessage.cs
@@ -5,12 +5,12 @@ using QSB.WorldSync;
 namespace QSB.Audio.Messages;
 
 
-public class PlayerAudioControllerOneShotMessage : QSBMessage<(AudioType audioType, uint userID)>
+public class PlayerAudioControllerOneShotMessage : QSBMessage<(AudioType audioType, uint userID, float pitch, float volume)>
 {
-	public PlayerAudioControllerOneShotMessage(AudioType audioType, uint userID) : base((audioType, userID)) { }
+	public PlayerAudioControllerOneShotMessage(AudioType audioType, uint userID, float pitch = 1f, float volume = 1f) : base((audioType, userID, pitch, volume)) { }
 
 	public override bool ShouldReceive => QSBWorldSync.AllObjectsReady;
 
 	public override void OnReceiveRemote() =>
-		QSBPlayerManager.GetPlayer(Data.userID)?.AudioController?.PlayOneShot(Data.audioType);
+		QSBPlayerManager.GetPlayer(Data.userID)?.AudioController?.PlayOneShot(Data.audioType, Data.pitch, Data.volume);
 }

--- a/QSB/Audio/Messages/PlayerMovementAudioFootstepMessage.cs
+++ b/QSB/Audio/Messages/PlayerMovementAudioFootstepMessage.cs
@@ -1,0 +1,16 @@
+﻿using QSB.Messaging;
+using QSB.Player;
+using QSB.WorldSync;
+
+namespace QSB.Audio.Messages;
+
+
+public class PlayerMovementAudioFootstepMessage : QSBMessage<(AudioType audioType, float pitch, uint userID)>
+{
+	public PlayerMovementAudioFootstepMessage(AudioType audioType, float pitch, uint userID) : base((audioType, pitch, userID)) { }
+
+	public override bool ShouldReceive => QSBWorldSync.AllObjectsReady;
+
+	public override void OnReceiveRemote() =>
+		QSBPlayerManager.GetPlayer(Data.userID)?.AudioController?.PlayFootstep(Data.audioType, Data.pitch);
+}

--- a/QSB/Audio/Messages/PlayerMovementAudioJumpMessage.cs
+++ b/QSB/Audio/Messages/PlayerMovementAudioJumpMessage.cs
@@ -1,0 +1,16 @@
+﻿using QSB.Messaging;
+using QSB.Player;
+using QSB.WorldSync;
+
+namespace QSB.Audio.Messages;
+
+
+public class PlayerMovementAudioJumpMessage : QSBMessage<(float pitch, uint userID)>
+{
+	public PlayerMovementAudioJumpMessage(float pitch, uint userID) : base((pitch, userID)) { }
+
+	public override bool ShouldReceive => QSBWorldSync.AllObjectsReady;
+
+	public override void OnReceiveRemote() =>
+		QSBPlayerManager.GetPlayer(Data.userID)?.AudioController?.OnJump(Data.pitch);
+}

--- a/QSB/Audio/Messages/ShipThrusterAudioOneShotMessage.cs
+++ b/QSB/Audio/Messages/ShipThrusterAudioOneShotMessage.cs
@@ -1,0 +1,21 @@
+﻿using QSB.Messaging;
+using QSB.ShipSync;
+using QSB.WorldSync;
+
+namespace QSB.Audio.Messages;
+
+
+public class ShipThrusterAudioOneShotMessage : QSBMessage<(AudioType audioType, float pitch, float volume)>
+{
+	public ShipThrusterAudioOneShotMessage(AudioType audioType, float pitch = 1f, float volume = 1f) : base((audioType, pitch, volume)) { }
+
+	public override bool ShouldReceive => QSBWorldSync.AllObjectsReady;
+
+	public override void OnReceiveRemote()
+	{
+		var source = ShipManager.Instance.ShipThrusterAudio._rotationalSource;
+		source.pitch = Data.pitch;
+		source.PlayOneShot(Data.audioType, Data.volume);
+	}
+
+}

--- a/QSB/Audio/Patches/PlayerAudioControllerPatches.cs
+++ b/QSB/Audio/Patches/PlayerAudioControllerPatches.cs
@@ -1,0 +1,36 @@
+﻿using HarmonyLib;
+using QSB.Audio.Messages;
+using QSB.Messaging;
+using QSB.Patches;
+using QSB.Player;
+
+namespace QSB.Audio.Patches;
+
+[HarmonyPatch]
+internal class PlayerAudioControllerPatches : QSBPatch
+{
+	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
+
+	private static void PlayOneShot(AudioType audioType) =>
+		new PlayerAudioControllerOneShotMessage(audioType, QSBPlayerManager.LocalPlayerId).Send();
+
+	[HarmonyPostfix]
+	[HarmonyPatch(typeof(PlayerAudioController), nameof(PlayerAudioController.PlayMarshmallowCatchFire))]
+	public static void PlayerAudioController_PlayMarshmallowCatchFire() => PlayOneShot(AudioType.ToolMarshmallowIgnite);
+
+	[HarmonyPostfix]
+	[HarmonyPatch(typeof(PlayerAudioController), nameof(PlayerAudioController.PlayMarshmallowBlowOut))]
+	public static void PlayerAudioController_PlayMarshmallowBlowOut() => PlayOneShot(AudioType.ToolMarshmallowBlowOut);
+
+	[HarmonyPostfix]
+	[HarmonyPatch(typeof(PlayerAudioController), nameof(PlayerAudioController.PlayMarshmallowEat))]
+	public static void PlayerAudioController_PlayMarshmallowEat() => PlayOneShot(AudioType.ToolMarshmallowEat);
+
+	[HarmonyPostfix]
+	[HarmonyPatch(typeof(PlayerAudioController), nameof(PlayerAudioController.PlayMarshmallowEatBurnt))]
+	public static void PlayerAudioController_PlayMarshmallowEatBurnt() => PlayOneShot(AudioType.ToolMarshmallowEatBurnt);
+
+	[HarmonyPostfix]
+	[HarmonyPatch(typeof(PlayerAudioController), nameof(PlayerAudioController.PlayMarshmallowReplace))]
+	public static void PlayerAudioController_PlayMarshmallowReplace() => PlayOneShot(AudioType.ToolMarshmallowReplace);
+}

--- a/QSB/Audio/Patches/PlayerAudioControllerPatches.cs
+++ b/QSB/Audio/Patches/PlayerAudioControllerPatches.cs
@@ -15,14 +15,6 @@ internal class PlayerAudioControllerPatches : QSBPatch
 		new PlayerAudioControllerOneShotMessage(audioType, QSBPlayerManager.LocalPlayerId).Send();
 
 	[HarmonyPostfix]
-	[HarmonyPatch(typeof(PlayerAudioController), nameof(PlayerAudioController.PlayMarshmallowCatchFire))]
-	public static void PlayerAudioController_PlayMarshmallowCatchFire() => PlayOneShot(AudioType.ToolMarshmallowIgnite);
-
-	[HarmonyPostfix]
-	[HarmonyPatch(typeof(PlayerAudioController), nameof(PlayerAudioController.PlayMarshmallowBlowOut))]
-	public static void PlayerAudioController_PlayMarshmallowBlowOut() => PlayOneShot(AudioType.ToolMarshmallowBlowOut);
-
-	[HarmonyPostfix]
 	[HarmonyPatch(typeof(PlayerAudioController), nameof(PlayerAudioController.PlayMarshmallowEat))]
 	public static void PlayerAudioController_PlayMarshmallowEat() => PlayOneShot(AudioType.ToolMarshmallowEat);
 
@@ -31,6 +23,14 @@ internal class PlayerAudioControllerPatches : QSBPatch
 	public static void PlayerAudioController_PlayMarshmallowEatBurnt() => PlayOneShot(AudioType.ToolMarshmallowEatBurnt);
 
 	[HarmonyPostfix]
-	[HarmonyPatch(typeof(PlayerAudioController), nameof(PlayerAudioController.PlayMarshmallowReplace))]
-	public static void PlayerAudioController_PlayMarshmallowReplace() => PlayOneShot(AudioType.ToolMarshmallowReplace);
+	[HarmonyPatch(typeof(PlayerAudioController), nameof(PlayerAudioController.PlayPatchPuncture))]
+	public static void PlayerAudioController_PlayPatchPuncture() => PlayOneShot(AudioType.PlayerSuitPatchPuncture);
+
+	[HarmonyPostfix]
+	[HarmonyPatch(typeof(PlayerAudioController), nameof(PlayerAudioController.PlayMedkit))]
+	public static void PlayerAudioController_PlayMedkit() => PlayOneShot(AudioType.ShipCabinUseMedkit);
+
+	[HarmonyPostfix]
+	[HarmonyPatch(typeof(PlayerAudioController), nameof(PlayerAudioController.PlayRefuel))]
+	public static void PlayerAudioController_PlayRefuel() => PlayOneShot(AudioType.ShipCabinUseRefueller);
 }

--- a/QSB/Audio/Patches/PlayerImpactAudioPatches.cs
+++ b/QSB/Audio/Patches/PlayerImpactAudioPatches.cs
@@ -1,0 +1,39 @@
+﻿using HarmonyLib;
+using QSB.Audio.Messages;
+using QSB.Messaging;
+using QSB.Patches;
+using QSB.Player;
+
+namespace QSB.Audio.Patches;
+
+internal class PlayerImpactAudioPatches : QSBPatch
+{
+	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
+
+	[HarmonyPostfix]
+	[HarmonyPatch(typeof(PlayerImpactAudio), nameof(PlayerImpactAudio.Start))]
+	public static void PlayerImpactAudio_Start(PlayerImpactAudio __instance)
+	{
+		__instance.gameObject.AddComponent<QSBAudioSourceOneShotTracker>();
+	}
+
+	[HarmonyPrefix]
+	[HarmonyPatch(typeof(PlayerImpactAudio), nameof(PlayerImpactAudio.OnImpact))]
+	public static void PlayerImpactAudio_OnImpact_Prefix(PlayerImpactAudio __instance) =>
+		// First we reset in case no audio is actually played
+		__instance.gameObject.GetComponent<QSBAudioSourceOneShotTracker>()?.Reset();
+
+	[HarmonyPostfix]
+	[HarmonyPatch(typeof(PlayerImpactAudio), nameof(PlayerImpactAudio.OnImpact))]
+	public static void PlayerImpactAudio_OnImpact_Postfix(PlayerImpactAudio __instance)
+	{
+		var tracker = __instance.gameObject.GetComponent<QSBAudioSourceOneShotTracker>();
+		if (tracker)
+		{
+			if (tracker.LastPlayed != AudioType.None)
+			{
+				new PlayerAudioControllerOneShotMessage(tracker.LastPlayed, QSBPlayerManager.LocalPlayerId, tracker.Pitch, tracker.Volume).Send();
+			}
+		}
+	}
+}

--- a/QSB/Audio/Patches/PlayerImpactAudioPatches.cs
+++ b/QSB/Audio/Patches/PlayerImpactAudioPatches.cs
@@ -8,7 +8,8 @@ namespace QSB.Audio.Patches;
 
 internal class PlayerImpactAudioPatches : QSBPatch
 {
-	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
+	// Since we patch Start we do it when the mod starts, else it won't run
+	public override QSBPatchTypes Type => QSBPatchTypes.OnModStart;
 
 	[HarmonyPostfix]
 	[HarmonyPatch(typeof(PlayerImpactAudio), nameof(PlayerImpactAudio.Start))]

--- a/QSB/Audio/Patches/PlayerMovementAudioPatches.cs
+++ b/QSB/Audio/Patches/PlayerMovementAudioPatches.cs
@@ -1,0 +1,32 @@
+﻿using HarmonyLib;
+using QSB.Audio.Messages;
+using QSB.Messaging;
+using QSB.Patches;
+using QSB.Player;
+
+namespace QSB.Audio.Patches;
+
+internal class PlayerMovementAudioPatches : QSBPatch
+{
+	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
+
+	[HarmonyPostfix]
+	[HarmonyPatch(typeof(PlayerMovementAudio), nameof(PlayerMovementAudio.PlayFootstep))]
+	public static void PlayerMovementAudio_PlayFootstep(PlayerMovementAudio __instance)
+	{
+		var underwater = !PlayerState.IsCameraUnderwater() && __instance._fluidDetector.InFluidType(FluidVolume.Type.WATER);
+		var audioType = underwater ? AudioType.MovementShallowWaterFootstep : PlayerMovementAudio.GetFootstepAudioType(__instance._playerController.GetGroundSurface());
+
+		if (audioType != AudioType.None)
+		{
+			new PlayerMovementAudioFootstepMessage(audioType, __instance._footstepAudio.pitch, QSBPlayerManager.LocalPlayerId).Send();
+		}
+	}
+
+	[HarmonyPostfix]
+	[HarmonyPatch(typeof(PlayerMovementAudio), nameof(PlayerMovementAudio.OnJump))]
+	public static void PlayerMovementAudio_OnJump(PlayerMovementAudio __instance)
+	{
+		new PlayerMovementAudioJumpMessage(__instance._jumpAudio.pitch, QSBPlayerManager.LocalPlayerId).Send();
+	}
+}

--- a/QSB/Audio/Patches/ThrusterAudioPatches.cs
+++ b/QSB/Audio/Patches/ThrusterAudioPatches.cs
@@ -1,0 +1,45 @@
+﻿using HarmonyLib;
+using QSB.Audio.Messages;
+using QSB.Messaging;
+using QSB.Patches;
+using QSB.Player;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QSB.Audio.Patches;
+
+internal class ThrusterAudioPatches : QSBPatch
+{
+	// Since we patch Start we do it when the mod starts, else it won't run
+	public override QSBPatchTypes Type => QSBPatchTypes.OnModStart;
+
+	[HarmonyPostfix]
+	[HarmonyPatch(typeof(ThrusterAudio), nameof(ThrusterAudio.Start))]
+	public static void ThrusterAudio_Start(ThrusterAudio __instance)
+	{
+		__instance._rotationalSource.gameObject.AddComponent<QSBAudioSourceOneShotTracker>();
+	}
+
+	[HarmonyPrefix]
+	[HarmonyPatch(typeof(ThrusterAudio), nameof(ThrusterAudio.OnFireRotationalThruster))]
+	public static void ThrusterAudio_OnFireRotationalThruster_Prefix(ThrusterAudio __instance) =>
+		// First we reset in case no audio is actually played
+		__instance._rotationalSource.gameObject.GetComponent<QSBAudioSourceOneShotTracker>()?.Reset();
+
+	[HarmonyPostfix]
+	[HarmonyPatch(typeof(ThrusterAudio), nameof(ThrusterAudio.OnFireRotationalThruster))]
+	public static void ThrusterAudio_OnFireRotationalThruster_Postfix(ThrusterAudio __instance)
+	{
+		if (__instance._rotationalSource.gameObject.TryGetComponent<QSBAudioSourceOneShotTracker>(out var tracker))
+		{
+			if (tracker.LastPlayed != AudioType.None)
+			{
+				if (__instance is ShipThrusterAudio)
+					new ShipThrusterAudioOneShotMessage(tracker.LastPlayed, tracker.Pitch, tracker.Volume).Send();
+			}
+		}
+	}
+}

--- a/QSB/Audio/Patches/ThrusterAudioPatches.cs
+++ b/QSB/Audio/Patches/ThrusterAudioPatches.cs
@@ -2,12 +2,6 @@
 using QSB.Audio.Messages;
 using QSB.Messaging;
 using QSB.Patches;
-using QSB.Player;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace QSB.Audio.Patches;
 
@@ -38,7 +32,9 @@ internal class ThrusterAudioPatches : QSBPatch
 			if (tracker.LastPlayed != AudioType.None)
 			{
 				if (__instance is ShipThrusterAudio)
+				{
 					new ShipThrusterAudioOneShotMessage(tracker.LastPlayed, tracker.Pitch, tracker.Volume).Send();
+				}
 			}
 		}
 	}

--- a/QSB/Audio/Patches/ThrusterAudioPatches.cs
+++ b/QSB/Audio/Patches/ThrusterAudioPatches.cs
@@ -35,6 +35,7 @@ internal class ThrusterAudioPatches : QSBPatch
 				{
 					new ShipThrusterAudioOneShotMessage(tracker.LastPlayed, tracker.Pitch, tracker.Volume).Send();
 				}
+				// TODO: Apply to player jetpack thruster?
 			}
 		}
 	}

--- a/QSB/Audio/QSBAudioSourceOneShotTracker.cs
+++ b/QSB/Audio/QSBAudioSourceOneShotTracker.cs
@@ -1,0 +1,63 @@
+﻿using HarmonyLib;
+using QSB.Patches;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace QSB.Audio;
+
+/// <summary>
+/// tracks what audioType was last played on when PlayOneShot is called on an OWAudioSource
+/// makes it easier to send a message afterwards syncing what was just played
+/// </summary>
+[RequireComponent(typeof(OWAudioSource))]
+public class QSBAudioSourceOneShotTracker : MonoBehaviour
+{
+	public AudioType LastPlayed { get; internal set; }
+	public float Pitch { get => _source.pitch; }
+	public float Volume { get; internal set; }
+	public int Index { get; internal set; }
+
+	public void Reset() => LastPlayed = AudioType.None;
+
+	private OWAudioSource _source;
+	public void Awake()
+	{
+		_source = GetComponent<OWAudioSource>();
+	}
+}
+
+[HarmonyPatch(typeof(OWAudioSource))]
+internal class OneShotTrackerPatches : QSBPatch
+{
+	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
+
+	[HarmonyPostfix]
+	[HarmonyPatch(nameof(OWAudioSource.PlayOneShot), new[] { typeof(AudioType), typeof(float) })]
+	private static void TrackOneShot_AudioType(OWAudioSource __instance, AudioType type, float volume)
+	{
+		var tracker = __instance.gameObject.GetComponent<QSBAudioSourceOneShotTracker>();
+		if (tracker)
+		{
+			tracker.LastPlayed = type;
+			tracker.Volume = volume;
+			tracker.Index = -1;
+		}
+	}
+
+	[HarmonyPostfix]
+	[HarmonyPatch(nameof(OWAudioSource.PlayOneShot), new[] { typeof(AudioType), typeof(int), typeof(float) })]
+	private static void TrackOneShot_AudioType(OWAudioSource __instance, AudioType type, int index, float volume)
+	{
+		var tracker = __instance.gameObject.GetComponent<QSBAudioSourceOneShotTracker>();
+		if (tracker)
+		{
+			tracker.LastPlayed = type;
+			tracker.Volume = volume;
+			tracker.Index = index;
+		}
+	}
+}

--- a/QSB/Audio/QSBJetpackThrusterAudio.cs
+++ b/QSB/Audio/QSBJetpackThrusterAudio.cs
@@ -1,4 +1,6 @@
-﻿using QSB.Utility;
+﻿using QSB.Player;
+using QSB.Utility;
+using UnityEngine;
 
 namespace QSB.Audio;
 
@@ -8,4 +10,70 @@ internal class QSBJetpackThrusterAudio : QSBThrusterAudio
 	public OWAudioSource _underwaterSource;
 	public OWAudioSource _oxygenSource;
 	public OWAudioSource _boostSource;
+
+	private PlayerInfo _attachedPlayer;
+	private bool _wasBoosting;
+
+	// Taken from Player_Body settings
+	private const float maxTranslationalThrust = 6f;
+
+	public void Init(PlayerInfo player)
+	{
+		_attachedPlayer = player;
+		enabled = true;
+	}
+
+	private void Update()
+	{
+		if(_attachedPlayer == null)
+		{
+			enabled = false;
+			return;
+		}
+
+		var acc = _attachedPlayer.JetpackAcceleration.AccelerationVariableSyncer.Value;
+		var thrustFraction = acc.magnitude / maxTranslationalThrust;
+
+		// TODO: Sync
+		var usingBooster = false;
+		var usingOxygen = false;
+		var underwater = false;
+
+		float targetVolume = usingBooster ? 0f : thrustFraction;
+		float targetPan = -acc.x / maxTranslationalThrust * 0.4f;
+		UpdateTranslationalSource(_translationalSource, targetVolume, targetPan, !underwater && !usingOxygen);
+		UpdateTranslationalSource(_underwaterSource, targetVolume, targetPan, underwater);
+		UpdateTranslationalSource(_oxygenSource, targetVolume, targetPan, !underwater && usingOxygen);
+
+		if (!_wasBoosting && usingBooster)
+		{
+			_boostSource.FadeIn(0.3f, false, false, 1f);
+		}
+		else if (_wasBoosting && !usingBooster)
+		{
+			_boostSource.FadeOut(0.3f, OWAudioSource.FadeOutCompleteAction.STOP, 0f);
+		}
+
+		_wasBoosting = usingBooster;
+	}
+
+	private void UpdateTranslationalSource(OWAudioSource source, float targetVolume, float targetPan, bool active)
+	{
+		if (!active)
+		{
+			targetVolume = 0f;
+			targetPan = 0f;
+		}
+		if (!source.isPlaying && targetVolume > 0f)
+		{
+			source.SetLocalVolume(0f);
+			source.Play();
+		}
+		else if (source.isPlaying && source.volume <= 0f)
+		{
+			source.Stop();
+		}
+		source.SetLocalVolume(Mathf.MoveTowards(source.GetLocalVolume(), targetVolume, 5f * Time.deltaTime));
+		source.panStereo = Mathf.MoveTowards(source.panStereo, targetPan, 5f * Time.deltaTime);
+	}
 }

--- a/QSB/Audio/QSBPlayerAudioController.cs
+++ b/QSB/Audio/QSBPlayerAudioController.cs
@@ -27,6 +27,18 @@ public class QSBPlayerAudioController : MonoBehaviour
 	public void PlayRemoveSuit()
 		=> PlayOneShot(AudioType.PlayerSuitRemoveSuit);
 
-	public void PlayOneShot(AudioType audioType) 
-		=> _oneShotExternalSource?.PlayOneShot(audioType, 1f);
+	public void PlayOneShot(AudioType audioType, float pitch = 1f, float volume = 1f)
+	{
+		if (_oneShotExternalSource)
+		{
+			_oneShotExternalSource.pitch = pitch;
+			_oneShotExternalSource.PlayOneShot(audioType, volume);
+		}
+	}
+
+	public void PlayFootstep(AudioType audioType, float pitch) => 
+		PlayOneShot(audioType, pitch, 0.7f);
+
+	public void OnJump(float pitch) =>
+		PlayOneShot(AudioType.MovementJump, pitch, 0.7f);
 }

--- a/QSB/Audio/QSBPlayerAudioController.cs
+++ b/QSB/Audio/QSBPlayerAudioController.cs
@@ -22,14 +22,11 @@ public class QSBPlayerAudioController : MonoBehaviour
 		=> _oneShotExternalSource?.PlayOneShot(AudioType.ToolFlashlightOff);
 
 	public void PlayWearSuit()
-		=> _oneShotExternalSource?.PlayOneShot(AudioType.PlayerSuitWearSuit);
+		=> PlayOneShot(AudioType.PlayerSuitWearSuit);
 
 	public void PlayRemoveSuit()
-		=> _oneShotExternalSource?.PlayOneShot(AudioType.PlayerSuitRemoveSuit);
+		=> PlayOneShot(AudioType.PlayerSuitRemoveSuit);
 
-	public void PlayWearHelmet()
-		=> _oneShotExternalSource?.PlayOneShot(AudioType.PlayerSuitWearHelmet);
-
-	public void PlayRemoveHelmet()
-		=> _oneShotExternalSource?.PlayOneShot(AudioType.PlayerSuitRemoveHelmet);
+	public void PlayOneShot(AudioType audioType) 
+		=> _oneShotExternalSource?.PlayOneShot(audioType, 1f);
 }

--- a/QSB/Audio/QSBPlayerAudioController.cs
+++ b/QSB/Audio/QSBPlayerAudioController.cs
@@ -20,4 +20,16 @@ public class QSBPlayerAudioController : MonoBehaviour
 
 	public void PlayTurnOffFlashlight()
 		=> _oneShotExternalSource?.PlayOneShot(AudioType.ToolFlashlightOff);
+
+	public void PlayWearSuit()
+		=> _oneShotExternalSource?.PlayOneShot(AudioType.PlayerSuitWearSuit);
+
+	public void PlayRemoveSuit()
+		=> _oneShotExternalSource?.PlayOneShot(AudioType.PlayerSuitRemoveSuit);
+
+	public void PlayWearHelmet()
+		=> _oneShotExternalSource?.PlayOneShot(AudioType.PlayerSuitWearHelmet);
+
+	public void PlayRemoveHelmet()
+		=> _oneShotExternalSource?.PlayOneShot(AudioType.PlayerSuitRemoveHelmet);
 }

--- a/QSB/Messaging/OWEvents.cs
+++ b/QSB/Messaging/OWEvents.cs
@@ -33,4 +33,7 @@ public static class OWEvents
 	public const string ExitDreamWorld = nameof(ExitDreamWorld);
 	public const string EnterRemoteFlightConsole = nameof(EnterRemoteFlightConsole);
 	public const string ExitRemoteFlightConsole = nameof(ExitRemoteFlightConsole);
+	public const string StartShipIgnition = nameof(StartShipIgnition);
+	public const string CompleteShipIgnition = nameof(CompleteShipIgnition);
+	public const string CancelShipIgnition = nameof(CancelShipIgnition);
 }

--- a/QSB/ModelShip/Messages/CrashModelShipMessage.cs
+++ b/QSB/ModelShip/Messages/CrashModelShipMessage.cs
@@ -1,0 +1,16 @@
+﻿using QSB.Messaging;
+using QSB.WorldSync;
+
+namespace QSB.ModelShip.Messages;
+
+internal class CrashModelShipMessage : QSBMessage
+{
+	public CrashModelShipMessage() { }
+
+	public override void OnReceiveRemote()
+	{
+		var crashBehaviour = QSBWorldSync.GetUnityObject<ModelShipCrashBehavior>();
+		crashBehaviour._crashEffect.Play();
+		crashBehaviour.gameObject.GetComponent<OWAudioSource>().PlayOneShot(AudioType.TH_ModelShipCrash);
+	}
+}

--- a/QSB/ModelShip/Messages/RespawnModelShipMessage.cs
+++ b/QSB/ModelShip/Messages/RespawnModelShipMessage.cs
@@ -8,6 +8,10 @@ internal class RespawnModelShipMessage : QSBMessage<bool>
 {
 	public RespawnModelShipMessage(bool playEffects) : base(playEffects) { }
 
-	public override void OnReceiveRemote() =>
-		QSBPatch.RemoteCall(() => QSBWorldSync.GetUnityObject<RemoteFlightConsole>().RespawnModelShip(Data));
+	public override void OnReceiveRemote()
+	{
+		var flightConsole = QSBWorldSync.GetUnityObject<RemoteFlightConsole>();
+		QSBPatch.RemoteCall(() => flightConsole.RespawnModelShip(Data));
+		if (Data) flightConsole._modelShipBody.GetComponent<OWAudioSource>().PlayOneShot(AudioType.TH_RetrieveModelShip);
+	}
 }

--- a/QSB/ModelShip/Messages/UseFlightConsoleMessage.cs
+++ b/QSB/ModelShip/Messages/UseFlightConsoleMessage.cs
@@ -28,6 +28,10 @@ internal class UseFlightConsoleMessage : QSBMessage<bool>
 
 	public override void OnReceiveLocal()
 	{
+		ModelShipManager.Instance.CurrentFlyer = Data
+			? From
+			: uint.MaxValue;
+
 		if (QSBCore.IsHost)
 		{
 			ModelShipTransformSync.LocalInstance.netIdentity.SetAuthority(Data
@@ -38,6 +42,10 @@ internal class UseFlightConsoleMessage : QSBMessage<bool>
 
 	public override void OnReceiveRemote()
 	{
+		ModelShipManager.Instance.CurrentFlyer = Data
+			? From
+			: uint.MaxValue;
+
 		var console = QSBWorldSync.GetUnityObject<RemoteFlightConsole>();
 
 		if (Data)

--- a/QSB/ModelShip/Messages/UseFlightConsoleMessage.cs
+++ b/QSB/ModelShip/Messages/UseFlightConsoleMessage.cs
@@ -33,6 +33,8 @@ internal class UseFlightConsoleMessage : QSBMessage<bool>
 	{
 		var console = QSBWorldSync.GetUnityObject<RemoteFlightConsole>();
 
+		SetCurrentFlyer(From, Data);
+
 		if (Data)
 		{
 			console._modelShipBody.Unsuspend();
@@ -55,8 +57,6 @@ internal class UseFlightConsoleMessage : QSBMessage<bool>
 
 		QSBWorldSync.GetUnityObject<ModelShipController>()._detector.SetActive(Data);
 		QSBWorldSync.GetUnityObjects<ModelShipLandingSpot>().ForEach(x => x._owCollider.SetActivation(Data));
-
-		SetCurrentFlyer(From, Data);
 	}
 
 	private void SetCurrentFlyer(uint flyer, bool isFlying)

--- a/QSB/ModelShip/Messages/UseFlightConsoleMessage.cs
+++ b/QSB/ModelShip/Messages/UseFlightConsoleMessage.cs
@@ -38,6 +38,11 @@ internal class UseFlightConsoleMessage : QSBMessage<bool>
 				? From
 				: QSBPlayerManager.LocalPlayerId);
 		}
+
+		// Client messes up its position when they start flying it
+		// We can just recall it immediately so its in the right place.
+		var console = QSBWorldSync.GetUnityObject<RemoteFlightConsole>();
+		console.RespawnModelShip(false);
 	}
 
 	public override void OnReceiveRemote()

--- a/QSB/ModelShip/ModelShipManager.cs
+++ b/QSB/ModelShip/ModelShipManager.cs
@@ -13,6 +13,28 @@ internal class ModelShipManager : WorldObjectManager
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.SolarSystem;
 	public override bool DlcOnly => false;
 
+	public static ModelShipManager Instance;
+
+	public uint CurrentFlyer
+	{
+		get => _currentFlyer;
+		set
+		{
+			if (_currentFlyer != uint.MaxValue && value != uint.MaxValue)
+			{
+				DebugLog.ToConsole($"Warning - Trying to set current model ship flyer while someone is still flying? Current:{_currentFlyer}, New:{value}", MessageType.Warning);
+			}
+
+			_currentFlyer = value;
+		}
+	}
+	private uint _currentFlyer = uint.MaxValue;
+
+	public void Start()
+	{
+		Instance = this;
+	}
+
 	public override async UniTask BuildWorldObjects(OWScene scene, CancellationToken ct)
 	{
 		if (QSBCore.IsHost)
@@ -20,7 +42,7 @@ internal class ModelShipManager : WorldObjectManager
 			Instantiate(QSBNetworkManager.singleton.ModelShipPrefab).SpawnWithServerAuthority();
 		}
 
-		// Is 0 by default -> 2D
+		// Is 0 by default -> 2D (bad)
 		QSBWorldSync.GetUnityObject<RemoteFlightConsole>()._consoleAudio.spatialBlend = 1;
 	}
 

--- a/QSB/ModelShip/ModelShipManager.cs
+++ b/QSB/ModelShip/ModelShipManager.cs
@@ -19,6 +19,9 @@ internal class ModelShipManager : WorldObjectManager
 		{
 			Instantiate(QSBNetworkManager.singleton.ModelShipPrefab).SpawnWithServerAuthority();
 		}
+
+		// Is 0 by default -> 2D
+		QSBWorldSync.GetUnityObject<RemoteFlightConsole>()._consoleAudio.spatialBlend = 1;
 	}
 
 	public override void UnbuildWorldObjects()

--- a/QSB/ModelShip/ModelShipThrusterVariableSyncer.cs
+++ b/QSB/ModelShip/ModelShipThrusterVariableSyncer.cs
@@ -18,15 +18,12 @@ public class ModelShipThrusterVariableSyncer : MonoBehaviour
 
 	public void Init(GameObject modelShip)
 	{
-		DebugLog.ToConsole("init model ship");
-
 		ThrusterModel = modelShip.GetComponent<ThrusterModel>();
 		_thrusterAudio = modelShip.GetComponentInChildren<ThrusterAudio>();
 
 		ThrusterFlameControllers.Clear();
 		foreach (var item in modelShip.GetComponentsInChildren<ThrusterFlameController>())
 		{
-			DebugLog.ToConsole("adding thruster");
 			ThrusterFlameControllers.Add(item);
 		}
 	}
@@ -35,48 +32,37 @@ public class ModelShipThrusterVariableSyncer : MonoBehaviour
 	{
 		if (QSBPlayerManager.LocalPlayer.FlyingModelShip)
 		{
-			DebugLog.ToConsole($"{QSBPlayerManager.LocalPlayerId} is flying the model ship");
 			GetFromShip();
 			return;
 		}
 
 		if (AccelerationSyncer.public_HasChanged())
 		{
-			DebugLog.ToConsole("value changed");
-
 			if (AccelerationSyncer.Value == Vector3.zero)
 			{
-				DebugLog.ToConsole("not flying");
 				foreach (var item in ThrusterFlameControllers)
 				{
 					item.OnStopTranslationalThrust();
 				}
 
 				_thrusterAudio.OnStopTranslationalThrust();
-
-
 			}
 			else
 			{
-				DebugLog.ToConsole("flying");
 				foreach (var item in ThrusterFlameControllers)
 				{
 					item.OnStartTranslationalThrust();
 				}
 
 				_thrusterAudio.OnStartTranslationalThrust();
-
-
 			}
 		}
 	}
 
 	private void GetFromShip()
 	{
-		DebugLog.ToConsole("Getting from ship");
 		if (ThrusterModel)
 		{
-			DebugLog.ToConsole("Update local acc");
 			AccelerationSyncer.Value = ThrusterModel.GetLocalAcceleration();
 		}
 	}

--- a/QSB/ModelShip/ModelShipThrusterVariableSyncer.cs
+++ b/QSB/ModelShip/ModelShipThrusterVariableSyncer.cs
@@ -1,0 +1,79 @@
+﻿using Mirror;
+using QSB.Player;
+using QSB.Utility.VariableSync;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace QSB.ModelShip;
+
+public class ModelShipThrusterVariableSyncer : NetworkBehaviour
+{
+	public Vector3VariableSyncer AccelerationSyncer;
+
+	private ThrusterModel _thrusterModel;
+	private ThrusterAudio _thrusterAudio;
+	public List<ThrusterFlameController> ThrusterFlameControllers = new();
+
+	public static ModelShipThrusterVariableSyncer LocalInstance;
+
+	public void Start()
+	{
+		LocalInstance = this;
+	}
+
+	public void Init()
+	{
+		_thrusterModel = gameObject.GetComponent<ThrusterModel>();
+		_thrusterAudio = gameObject.GetComponentInChildren<ThrusterAudio>();
+
+		ThrusterFlameControllers.Clear();
+		foreach (var item in gameObject.GetComponentsInChildren<ThrusterFlameController>())
+		{
+			ThrusterFlameControllers.Add(item);
+		}
+	}
+
+	public void Update()
+	{
+		if (QSBPlayerManager.LocalPlayer.FlyingModelShip)
+		{
+			GetFromShip();
+			return;
+		}
+
+		if (AccelerationSyncer.public_HasChanged())
+		{
+			if (AccelerationSyncer.Value == Vector3.zero)
+			{
+				foreach (var item in ThrusterFlameControllers)
+				{
+					item.OnStopTranslationalThrust();
+				}
+
+				_thrusterAudio.OnStopTranslationalThrust();
+
+
+			}
+			else
+			{
+				foreach (var item in ThrusterFlameControllers)
+				{
+					item.OnStartTranslationalThrust();
+				}
+
+				_thrusterAudio.OnStartTranslationalThrust();
+
+
+			}
+		}
+	}
+
+	private void GetFromShip()
+	{
+		if (_thrusterModel)
+		{
+			AccelerationSyncer.Value = _thrusterModel.GetLocalAcceleration();
+		}
+	}
+}

--- a/QSB/ModelShip/ModelShipThrusterVariableSyncer.cs
+++ b/QSB/ModelShip/ModelShipThrusterVariableSyncer.cs
@@ -12,7 +12,7 @@ public class ModelShipThrusterVariableSyncer : MonoBehaviour
 {
 	public Vector3VariableSyncer AccelerationSyncer;
 
-	private ThrusterModel _thrusterModel;
+	public ThrusterModel ThrusterModel { get; private set; }
 	private ThrusterAudio _thrusterAudio;
 	public List<ThrusterFlameController> ThrusterFlameControllers = new();
 
@@ -20,7 +20,7 @@ public class ModelShipThrusterVariableSyncer : MonoBehaviour
 	{
 		DebugLog.ToConsole("init model ship");
 
-		_thrusterModel = modelShip.GetComponent<ThrusterModel>();
+		ThrusterModel = modelShip.GetComponent<ThrusterModel>();
 		_thrusterAudio = modelShip.GetComponentInChildren<ThrusterAudio>();
 
 		ThrusterFlameControllers.Clear();
@@ -74,10 +74,10 @@ public class ModelShipThrusterVariableSyncer : MonoBehaviour
 	private void GetFromShip()
 	{
 		DebugLog.ToConsole("Getting from ship");
-		if (_thrusterModel)
+		if (ThrusterModel)
 		{
 			DebugLog.ToConsole("Update local acc");
-			AccelerationSyncer.Value = _thrusterModel.GetLocalAcceleration();
+			AccelerationSyncer.Value = ThrusterModel.GetLocalAcceleration();
 		}
 	}
 }

--- a/QSB/ModelShip/ModelShipThrusterVariableSyncer.cs
+++ b/QSB/ModelShip/ModelShipThrusterVariableSyncer.cs
@@ -15,6 +15,7 @@ public class ModelShipThrusterVariableSyncer : MonoBehaviour
 	public ThrusterModel ThrusterModel { get; private set; }
 	private ThrusterAudio _thrusterAudio;
 	public List<ThrusterFlameController> ThrusterFlameControllers = new();
+	public ThrusterWashController ThrusterWashController { get; private set; }
 
 	public void Init(GameObject modelShip)
 	{
@@ -26,6 +27,8 @@ public class ModelShipThrusterVariableSyncer : MonoBehaviour
 		{
 			ThrusterFlameControllers.Add(item);
 		}
+
+		ThrusterWashController = modelShip.GetComponentInChildren<ThrusterWashController>();
 	}
 
 	public void Update()
@@ -46,6 +49,8 @@ public class ModelShipThrusterVariableSyncer : MonoBehaviour
 				}
 
 				_thrusterAudio.OnStopTranslationalThrust();
+
+				ThrusterWashController.OnStopTranslationalThrust();
 			}
 			else
 			{
@@ -55,6 +60,8 @@ public class ModelShipThrusterVariableSyncer : MonoBehaviour
 				}
 
 				_thrusterAudio.OnStartTranslationalThrust();
+
+				ThrusterWashController.OnStartTranslationalThrust();
 			}
 		}
 	}

--- a/QSB/ModelShip/ModelShipThrusterVariableSyncer.cs
+++ b/QSB/ModelShip/ModelShipThrusterVariableSyncer.cs
@@ -1,5 +1,6 @@
 ﻿using Mirror;
 using QSB.Player;
+using QSB.Utility;
 using QSB.Utility.VariableSync;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,7 +8,7 @@ using UnityEngine;
 
 namespace QSB.ModelShip;
 
-public class ModelShipThrusterVariableSyncer : NetworkBehaviour
+public class ModelShipThrusterVariableSyncer : MonoBehaviour
 {
 	public Vector3VariableSyncer AccelerationSyncer;
 
@@ -15,21 +16,17 @@ public class ModelShipThrusterVariableSyncer : NetworkBehaviour
 	private ThrusterAudio _thrusterAudio;
 	public List<ThrusterFlameController> ThrusterFlameControllers = new();
 
-	public static ModelShipThrusterVariableSyncer LocalInstance;
-
-	public void Start()
+	public void Init(GameObject modelShip)
 	{
-		LocalInstance = this;
-	}
+		DebugLog.ToConsole("init model ship");
 
-	public void Init()
-	{
-		_thrusterModel = gameObject.GetComponent<ThrusterModel>();
-		_thrusterAudio = gameObject.GetComponentInChildren<ThrusterAudio>();
+		_thrusterModel = modelShip.GetComponent<ThrusterModel>();
+		_thrusterAudio = modelShip.GetComponentInChildren<ThrusterAudio>();
 
 		ThrusterFlameControllers.Clear();
-		foreach (var item in gameObject.GetComponentsInChildren<ThrusterFlameController>())
+		foreach (var item in modelShip.GetComponentsInChildren<ThrusterFlameController>())
 		{
+			DebugLog.ToConsole("adding thruster");
 			ThrusterFlameControllers.Add(item);
 		}
 	}
@@ -38,14 +35,18 @@ public class ModelShipThrusterVariableSyncer : NetworkBehaviour
 	{
 		if (QSBPlayerManager.LocalPlayer.FlyingModelShip)
 		{
+			DebugLog.ToConsole($"{QSBPlayerManager.LocalPlayerId} is flying the model ship");
 			GetFromShip();
 			return;
 		}
 
 		if (AccelerationSyncer.public_HasChanged())
 		{
+			DebugLog.ToConsole("value changed");
+
 			if (AccelerationSyncer.Value == Vector3.zero)
 			{
+				DebugLog.ToConsole("not flying");
 				foreach (var item in ThrusterFlameControllers)
 				{
 					item.OnStopTranslationalThrust();
@@ -57,6 +58,7 @@ public class ModelShipThrusterVariableSyncer : NetworkBehaviour
 			}
 			else
 			{
+				DebugLog.ToConsole("flying");
 				foreach (var item in ThrusterFlameControllers)
 				{
 					item.OnStartTranslationalThrust();
@@ -71,8 +73,10 @@ public class ModelShipThrusterVariableSyncer : NetworkBehaviour
 
 	private void GetFromShip()
 	{
+		DebugLog.ToConsole("Getting from ship");
 		if (_thrusterModel)
 		{
+			DebugLog.ToConsole("Update local acc");
 			AccelerationSyncer.Value = _thrusterModel.GetLocalAcceleration();
 		}
 	}

--- a/QSB/ModelShip/Patches/ModelShipPatches.cs
+++ b/QSB/ModelShip/Patches/ModelShipPatches.cs
@@ -2,6 +2,7 @@
 using QSB.Messaging;
 using QSB.ModelShip.Messages;
 using QSB.Patches;
+using UnityEngine;
 
 namespace QSB.ModelShip.Patches;
 
@@ -19,5 +20,15 @@ public class ModelShipPatches : QSBPatch
 		}
 
 		new RespawnModelShipMessage(playEffects).Send();
+	}
+
+	[HarmonyPrefix]
+	[HarmonyPatch(typeof(ModelShipCrashBehavior), nameof(ModelShipCrashBehavior.OnImpact))]
+	private static void ModelShipCrashBehavior_OnImpact(ModelShipCrashBehavior __instance, ImpactData impactData)
+	{
+		if (impactData.speed > 10f && Time.time > __instance._lastCrashTime + 1f)
+		{
+			new CrashModelShipMessage().Send();
+		}
 	}
 }

--- a/QSB/ModelShip/Patches/ModelShipThrusterAudioPatches.cs
+++ b/QSB/ModelShip/Patches/ModelShipThrusterAudioPatches.cs
@@ -1,0 +1,31 @@
+﻿using HarmonyLib;
+using QSB.ModelShip.TransformSync;
+using QSB.Patches;
+using QSB.Player;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QSB.ModelShip.Patches;
+
+internal class ModelShipThrusterAudioPatches : QSBPatch
+{
+	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
+
+	[HarmonyPrefix]
+	[HarmonyPatch(typeof(ThrusterModel), nameof(ThrusterModel.GetThrustFraction))]
+	public static bool ThrusterModel_GetThrustFraction(ThrusterModel __instance, ref float __result)
+	{
+		if (__instance == ModelShipTransformSync.LocalInstance.ThrusterVariableSyncer.ThrusterModel && !QSBPlayerManager.LocalPlayer.FlyingModelShip)
+		{
+			__result = ModelShipTransformSync.LocalInstance.ThrusterVariableSyncer.AccelerationSyncer.Value.magnitude / __instance._maxTranslationalThrust;
+			return false;
+		}
+		else
+		{
+			return true;
+		}
+	}
+}

--- a/QSB/ModelShip/Patches/ModelShipThrusterPatches.cs
+++ b/QSB/ModelShip/Patches/ModelShipThrusterPatches.cs
@@ -1,0 +1,39 @@
+﻿using HarmonyLib;
+using QSB.Patches;
+using QSB.Player;
+using System.Linq;
+using UnityEngine;
+
+namespace QSB.ModelShip.Patches;
+
+internal class ModelShipThrusterPatches : QSBPatch
+{
+	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
+
+	[HarmonyPrefix]
+	[HarmonyPatch(typeof(ThrusterFlameController), nameof(ThrusterFlameController.GetThrustFraction))]
+	public static bool GetThrustFraction(ThrusterFlameController __instance, ref float __result)
+	{
+		if (!ModelShipThrusterVariableSyncer.LocalInstance.ThrusterFlameControllers.Contains(__instance))
+		{
+			return true;
+		}
+
+		if (!__instance._thrusterModel.IsThrusterBankEnabled(OWUtilities.GetShipThrusterBank(__instance._thruster)))
+		{
+			__result = 0f;
+			return false;
+		}
+
+		if (QSBPlayerManager.LocalPlayer.FlyingModelShip)
+		{
+			__result = Vector3.Dot(__instance._thrusterModel.GetLocalAcceleration(), __instance._thrusterFilter);
+		}
+		else
+		{
+			__result = Vector3.Dot(ModelShipThrusterVariableSyncer.LocalInstance.AccelerationSyncer.Value, __instance._thrusterFilter);
+		}
+
+		return false;
+	}
+}

--- a/QSB/ModelShip/TransformSync/ModelShipTransformSync.cs
+++ b/QSB/ModelShip/TransformSync/ModelShipTransformSync.cs
@@ -1,4 +1,5 @@
-﻿using QSB.Syncs.Sectored.Rigidbodies;
+﻿using QSB.ShipSync;
+using QSB.Syncs.Sectored.Rigidbodies;
 using QSB.Utility;
 using QSB.WorldSync;
 
@@ -7,6 +8,8 @@ namespace QSB.ModelShip.TransformSync;
 internal class ModelShipTransformSync : SectoredRigidbodySync
 {
 	public static ModelShipTransformSync LocalInstance { get; private set; }
+
+	public ModelShipThrusterVariableSyncer ThrusterVariableSyncer { get; private set; }
 
 	public override void OnStartClient()
 	{
@@ -29,6 +32,14 @@ internal class ModelShipTransformSync : SectoredRigidbodySync
 		var modelShip = QSBWorldSync.GetUnityObject<RemoteFlightConsole>()._modelShipBody;
 		SectorDetector.Init(modelShip.transform.Find("Detector").GetComponent<SectorDetector>());
 		return modelShip;
+	}
+
+	protected override void Init()
+	{
+		base.Init();
+
+		ThrusterVariableSyncer = this.GetRequiredComponent<ModelShipThrusterVariableSyncer>();
+		ThrusterVariableSyncer.Init(AttachedRigidbody.gameObject);
 	}
 
 	/// <summary>

--- a/QSB/Player/PlayerInfo.cs
+++ b/QSB/Player/PlayerInfo.cs
@@ -3,6 +3,7 @@ using QSB.Animation.Player;
 using QSB.Audio;
 using QSB.ClientServerStateSync;
 using QSB.Messaging;
+using QSB.ModelShip;
 using QSB.Player.Messages;
 using QSB.Player.TransformSync;
 using QSB.QuantumSync.WorldObjects;
@@ -34,6 +35,7 @@ public partial class PlayerInfo
 	public bool IsLocalPlayer => TransformSync.isLocalPlayer; // if TransformSync is ever null, i give permission for nebula to make fun of me about it for the rest of time - johncorby
 	public ThrusterLightTracker ThrusterLightTracker;
 	public bool FlyingShip => ShipManager.Instance.CurrentFlyer == PlayerId;
+	public bool FlyingModelShip => ModelShipManager.Instance.CurrentFlyer == PlayerId;
 
 	public PlayerInfo(PlayerTransformSync transformSync)
 	{

--- a/QSB/QSBNetworkManager.cs
+++ b/QSB/QSBNetworkManager.cs
@@ -13,6 +13,7 @@ using QSB.EchoesOfTheEye.EclipseElevators.VariableSync;
 using QSB.EchoesOfTheEye.RaftSync.TransformSync;
 using QSB.JellyfishSync.TransformSync;
 using QSB.Messaging;
+using QSB.ModelShip;
 using QSB.ModelShip.TransformSync;
 using QSB.OrbSync.Messages;
 using QSB.OrbSync.TransformSync;
@@ -149,6 +150,9 @@ public class QSBNetworkManager : NetworkManager, IAddComponentOnStart
 		spawnPrefabs.Add(ShipLegPrefab);
 
 		ModelShipPrefab = MakeNewNetworkObject(14, "NetworkModelShip", typeof(ModelShipTransformSync));
+		var modelShipVector3Syncer = ModelShipPrefab.AddComponent<Vector3VariableSyncer>();
+		var modelShipThrusterVariableSyncer = ModelShipPrefab.AddComponent<ModelShipThrusterVariableSyncer>();
+		modelShipThrusterVariableSyncer.AccelerationSyncer = modelShipVector3Syncer;
 		spawnPrefabs.Add(ModelShipPrefab);
 
 		StationaryProbeLauncherPrefab = MakeNewNetworkObject(15, "NetworkStationaryProbeLauncher", typeof(StationaryProbeLauncherVariableSyncer));

--- a/QSB/RoastingSync/QSBMarshmallow.cs
+++ b/QSB/RoastingSync/QSBMarshmallow.cs
@@ -53,6 +53,8 @@ public class QSBMarshmallow : MonoBehaviour
 		_mallowRenderer.enabled = true;
 		_mallowState = Marshmallow.MallowState.Default;
 		enabled = true;
+
+		_attachedPlayer.AudioController.PlayOneShot(AudioType.ToolMarshmallowReplace);
 	}
 
 	public void Disable()
@@ -68,6 +70,8 @@ public class QSBMarshmallow : MonoBehaviour
 		{
 			_fireRenderer.enabled = false;
 			_mallowState = Marshmallow.MallowState.Default;
+
+			_attachedPlayer.AudioController.PlayOneShot(AudioType.ToolMarshmallowBlowOut);
 		}
 	}
 
@@ -142,6 +146,8 @@ public class QSBMarshmallow : MonoBehaviour
 			_toastedFraction = 1f;
 			_initBurnTime = Time.time;
 			_mallowState = Marshmallow.MallowState.Burning;
+
+			_attachedPlayer.AudioController.PlayOneShot(AudioType.ToolMarshmallowIgnite);
 		}
 	}
 

--- a/QSB/ShipSync/Messages/FlyShipMessage.cs
+++ b/QSB/ShipSync/Messages/FlyShipMessage.cs
@@ -39,12 +39,12 @@ internal class FlyShipMessage : QSBMessage<bool>
 		var shipCockpitController = ShipManager.Instance.CockpitController;
 		if (Data)
 		{
-			QSBPlayerManager.GetPlayer(From).AudioController.PlayOneShot(AudioType.ShipCockpitBuckleUp);
+			QSBPlayerManager.GetPlayer(From)?.AudioController?.PlayOneShot(AudioType.ShipCockpitBuckleUp);
 			shipCockpitController._interactVolume.DisableInteraction();
 		}
 		else
 		{
-			QSBPlayerManager.GetPlayer(From).AudioController.PlayOneShot(AudioType.ShipCockpitUnbuckle);
+			QSBPlayerManager.GetPlayer(From)?.AudioController?.PlayOneShot(AudioType.ShipCockpitUnbuckle);
 			shipCockpitController._interactVolume.EnableInteraction();
 		}
 	}

--- a/QSB/ShipSync/Messages/FlyShipMessage.cs
+++ b/QSB/ShipSync/Messages/FlyShipMessage.cs
@@ -39,10 +39,12 @@ internal class FlyShipMessage : QSBMessage<bool>
 		var shipCockpitController = ShipManager.Instance.CockpitController;
 		if (Data)
 		{
+			QSBPlayerManager.GetPlayer(From).AudioController.PlayOneShot(AudioType.ShipCockpitBuckleUp);
 			shipCockpitController._interactVolume.DisableInteraction();
 		}
 		else
 		{
+			QSBPlayerManager.GetPlayer(From).AudioController.PlayOneShot(AudioType.ShipCockpitUnbuckle);
 			shipCockpitController._interactVolume.EnableInteraction();
 		}
 	}

--- a/QSB/ShipSync/Messages/ShipIgnitionMessage.cs
+++ b/QSB/ShipSync/Messages/ShipIgnitionMessage.cs
@@ -1,0 +1,48 @@
+﻿using QSB.Messaging;
+using QSB.Player;
+using static QSB.ShipSync.Messages.ShipIgnitionMessage;
+
+namespace QSB.ShipSync.Messages;
+
+internal class ShipIgnitionMessage : QSBMessage<ShipIgnitionType>
+{
+    public enum ShipIgnitionType
+    {
+        START_IGNITION,
+        COMPLETE_IGNITION,
+        CANCEL_IGNITION
+    }
+
+    static ShipIgnitionMessage()
+    {
+        GlobalMessenger.AddListener(OWEvents.StartShipIgnition, () => Handler(ShipIgnitionType.START_IGNITION));
+        GlobalMessenger.AddListener(OWEvents.CompleteShipIgnition, () => Handler(ShipIgnitionType.COMPLETE_IGNITION));
+        GlobalMessenger.AddListener(OWEvents.CancelShipIgnition, () => Handler(ShipIgnitionType.CANCEL_IGNITION));
+    }
+
+    public ShipIgnitionMessage(ShipIgnitionType data) : base(data) { }
+
+    private static void Handler(ShipIgnitionType type)
+    {
+        if (QSBPlayerManager.LocalPlayer.FlyingShip)
+        {
+            new ShipIgnitionMessage(type).Send();
+        }
+    }
+
+    public override void OnReceiveRemote()
+    {
+		switch (Data)
+		{
+			case ShipIgnitionType.START_IGNITION:
+				GlobalMessenger.FireEvent(OWEvents.StartShipIgnition);
+				break;
+			case ShipIgnitionType.COMPLETE_IGNITION:
+				GlobalMessenger.FireEvent(OWEvents.CompleteShipIgnition);
+				break;
+			case ShipIgnitionType.CANCEL_IGNITION:
+				GlobalMessenger.FireEvent(OWEvents.CancelShipIgnition);
+				break;
+		}
+	}
+}

--- a/QSB/ShipSync/Patches/ShipAudioPatches.cs
+++ b/QSB/ShipSync/Patches/ShipAudioPatches.cs
@@ -1,0 +1,43 @@
+﻿using HarmonyLib;
+using QSB.Patches;
+using QSB.Player;
+using QSB.ShipSync.TransformSync;
+using UnityEngine;
+
+namespace QSB.ShipSync.Patches;
+
+internal class ShipAudioPatches : QSBPatch
+{
+	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
+
+	[HarmonyPrefix]
+	[HarmonyPatch(typeof(ShipThrusterAudio), nameof(ShipThrusterAudio.Update))]
+	public static bool ShipThrusterAudio_Update(ShipThrusterAudio __instance)
+	{
+		if (!QSBPlayerManager.LocalPlayer.FlyingShip)
+		{
+			Vector3 localAcceleration = ShipTransformSync.LocalInstance.ThrusterVariableSyncer.AccelerationSyncer.Value;
+			localAcceleration.y *= 0.5f;
+			localAcceleration.z *= 0.5f;
+			Vector3 vector = __instance._thrusterModel.IsThrusterBankEnabled(ThrusterBank.Left) ? localAcceleration : Vector3.zero;
+			vector.x = Mathf.Max(0f, vector.x);
+			Vector3 vector2 = __instance._thrusterModel.IsThrusterBankEnabled(ThrusterBank.Right) ? localAcceleration : Vector3.zero;
+			vector2.x = Mathf.Min(0f, vector2.x);
+			float maxTranslationalThrust = __instance._thrusterModel.GetMaxTranslationalThrust();
+			__instance.UpdateTranslationalSourceVolume(__instance._leftTranslationalSource, __instance._thrustToVolumeCurve.Evaluate(vector.magnitude / maxTranslationalThrust), !__instance._underwater);
+			__instance.UpdateTranslationalSourceVolume(__instance._rightTranslationalSource, __instance._thrustToVolumeCurve.Evaluate(vector2.magnitude / maxTranslationalThrust), !__instance._underwater);
+			__instance.UpdateTranslationalSourceVolume(__instance._leftUnderwaterSource, __instance._thrustToVolumeCurve.Evaluate(vector.magnitude / maxTranslationalThrust), __instance._underwater);
+			__instance.UpdateTranslationalSourceVolume(__instance._rightUnderwaterSource, __instance._thrustToVolumeCurve.Evaluate(vector2.magnitude / maxTranslationalThrust), __instance._underwater);
+			if (!__instance._thrustersFiring && !__instance._leftTranslationalSource.isPlaying && !__instance._rightTranslationalSource.isPlaying && !__instance._leftUnderwaterSource.isPlaying && !__instance._rightUnderwaterSource.isPlaying)
+			{
+				__instance.enabled = false;
+			}
+
+			return false;
+		}
+		else
+		{
+			return true;
+		}
+	}
+}

--- a/QSB/ShipSync/Patches/ShipAudioPatches.cs
+++ b/QSB/ShipSync/Patches/ShipAudioPatches.cs
@@ -16,6 +16,7 @@ internal class ShipAudioPatches : QSBPatch
 	{
 		if (!QSBPlayerManager.LocalPlayer.FlyingShip)
 		{
+			// Just copy pasted the original method with this one line changed
 			Vector3 localAcceleration = ShipTransformSync.LocalInstance.ThrusterVariableSyncer.AccelerationSyncer.Value;
 			localAcceleration.y *= 0.5f;
 			localAcceleration.z *= 0.5f;

--- a/QSB/ShipSync/Patches/ShipFlameWashPatches.cs
+++ b/QSB/ShipSync/Patches/ShipFlameWashPatches.cs
@@ -1,4 +1,6 @@
 ﻿using HarmonyLib;
+using QSB.ModelShip;
+using QSB.ModelShip.TransformSync;
 using QSB.Patches;
 using QSB.Player;
 using QSB.ShipSync.TransformSync;
@@ -41,16 +43,34 @@ internal class ShipFlameWashPatches : QSBPatch
 	[HarmonyPatch(typeof(ThrusterWashController), nameof(ThrusterWashController.Update))]
 	public static bool Update(ThrusterWashController __instance)
 	{
-		if (ShipThrusterManager.ShipWashController != __instance)
+		var isShip = ShipThrusterManager.ShipWashController == __instance;
+		var isModelShip = ModelShipTransformSync.LocalInstance.ThrusterVariableSyncer.ThrusterWashController == __instance;
+
+		if (!isShip && !isModelShip)
 		{
 			return true;
 		}
 
+		bool isLocal;
+		Vector3 remoteAcceleration;
+		if (isShip)
+		{
+			isLocal = QSBPlayerManager.LocalPlayer.FlyingShip;
+			remoteAcceleration = ShipTransformSync.LocalInstance.ThrusterVariableSyncer.AccelerationSyncer.Value;
+		}
+		else
+		{
+			isLocal = QSBPlayerManager.LocalPlayer.FlyingModelShip;
+			remoteAcceleration = ModelShipTransformSync.LocalInstance.ThrusterVariableSyncer.AccelerationSyncer.Value;
+		}
+
+		var localAcceleration = isLocal
+			? __instance._thrusterModel.GetLocalAcceleration()
+			: remoteAcceleration;
+
+		// The rest of this is just copy pasted from the original method
 		var hitInfo = default(RaycastHit);
 		var aboveGround = false;
-		var localAcceleration = QSBPlayerManager.LocalPlayer.FlyingShip
-			? __instance._thrusterModel.GetLocalAcceleration()
-			: ShipTransformSync.LocalInstance.ThrusterVariableSyncer.AccelerationSyncer.Value;
 		var emissionScale = __instance._emissionThrusterScale.Evaluate(localAcceleration.y);
 		if (emissionScale > 0f)
 		{

--- a/QSB/ShipSync/ShipManager.cs
+++ b/QSB/ShipSync/ShipManager.cs
@@ -136,6 +136,9 @@ internal class ShipManager : WorldObjectManager
 
 		QSBWorldSync.Init<QSBShipDetachableModule, ShipDetachableModule>();
 		QSBWorldSync.Init<QSBShipDetachableLeg, ShipDetachableLeg>();
+
+		// Make sure ignition source is 3D
+		QSBWorldSync.GetUnityObject<ShipThrusterAudio>()._ignitionSource.spatialBlend = 1f;
 	}
 
 	public override void UnbuildWorldObjects()

--- a/QSB/ShipSync/ShipManager.cs
+++ b/QSB/ShipSync/ShipManager.cs
@@ -139,8 +139,9 @@ internal class ShipManager : WorldObjectManager
 		QSBWorldSync.Init<QSBShipDetachableModule, ShipDetachableModule>();
 		QSBWorldSync.Init<QSBShipDetachableLeg, ShipDetachableLeg>();
 
-		// Make sure ignition source is 3D
+		// Make sure all relevant audio sources are 3D
 		QSBWorldSync.GetUnityObject<ShipThrusterAudio>()._ignitionSource.spatialBlend = 1f;
+		QSBWorldSync.GetUnityObject<ShipThrusterAudio>()._rotationalSource.spatialBlend = 1f;
 	}
 
 	public override void UnbuildWorldObjects()

--- a/QSB/ShipSync/ShipManager.cs
+++ b/QSB/ShipSync/ShipManager.cs
@@ -22,6 +22,7 @@ internal class ShipManager : WorldObjectManager
 
 	public static ShipManager Instance;
 
+	public ShipThrusterAudio ShipThrusterAudio;
 	public InteractZone HatchInteractZone;
 	public HatchController HatchController;
 	public ShipTractorBeamSwitch ShipTractorBeam;
@@ -92,6 +93,7 @@ internal class ShipManager : WorldObjectManager
 			return;
 		}
 
+		ShipThrusterAudio = QSBWorldSync.GetUnityObject<ShipThrusterAudio>();
 		HatchInteractZone = HatchController.GetComponent<InteractZone>();
 		ShipTractorBeam = QSBWorldSync.GetUnityObject<ShipTractorBeamSwitch>();
 		CockpitController = QSBWorldSync.GetUnityObject<ShipCockpitController>();

--- a/QSB/ShipSync/ShipThrusterVariableSyncer.cs
+++ b/QSB/ShipSync/ShipThrusterVariableSyncer.cs
@@ -1,6 +1,7 @@
 ﻿using Mirror;
 using QSB.Player;
 using QSB.Utility.VariableSync;
+using QSB.WorldSync;
 using UnityEngine;
 
 namespace QSB.ShipSync;
@@ -10,10 +11,12 @@ public class ShipThrusterVariableSyncer : NetworkBehaviour
 	public Vector3VariableSyncer AccelerationSyncer;
 
 	private ShipThrusterModel _thrusterModel;
+	private ShipThrusterAudio _thrusterAudio;
 
 	public void Init()
 	{
 		_thrusterModel = Locator.GetShipBody().GetComponent<ShipThrusterModel>();
+		_thrusterAudio = Locator.GetShipBody().GetComponentInChildren<ShipThrusterAudio>();
 	}
 
 	public void Update()
@@ -33,6 +36,8 @@ public class ShipThrusterVariableSyncer : NetworkBehaviour
 					item.OnStopTranslationalThrust();
 				}
 
+				_thrusterAudio.OnStopTranslationalThrust();
+
 				ShipThrusterManager.ShipWashController.OnStopTranslationalThrust();
 			}
 			else
@@ -41,6 +46,8 @@ public class ShipThrusterVariableSyncer : NetworkBehaviour
 				{
 					item.OnStartTranslationalThrust();
 				}
+
+				_thrusterAudio.OnStartTranslationalThrust();
 
 				ShipThrusterManager.ShipWashController.OnStartTranslationalThrust();
 			}


### PR DESCRIPTION
## SFX
- Footsteps
- Jumping
- Marshmallow ignite/blow out/eat/replace
- Suit up & remove suit
- Player impact sounds
- Ship buckle/unbuckle
- Ship ignition & thrusters
- Player jetpack thruster
- Model ship recall, crash, and thrusters

## VFX
- Model ship crash and thrusters

## Fixes
- Fixed bug where when the client starts flying the model ship it would update its position to be wrong

The jetpack thruster SFX sync doesn't include the sound differences for underwater and when using the booster since those values aren't synced at all currently for players.