### PR TITLE
Dream lantern fixes

### DIFF
--- a/QSB/Audio/Messages/PlayerAudioControllerUpdateHazardDamageMessage.cs
+++ b/QSB/Audio/Messages/PlayerAudioControllerUpdateHazardDamageMessage.cs
@@ -1,0 +1,12 @@
+﻿using QSB.Messaging;
+using QSB.Player;
+
+namespace QSB.Audio.Messages;
+
+internal class PlayerAudioControllerUpdateHazardDamageMessage : QSBMessage<(uint userID, HazardVolume.HazardType latestHazardType)>
+{
+	public PlayerAudioControllerUpdateHazardDamageMessage((uint userID, HazardVolume.HazardType latestHazardType) data) : base(data) { }
+
+	public override void OnReceiveRemote() =>
+		QSBPlayerManager.GetPlayer(Data.userID)?.AudioController.SetHazardDamage(Data.latestHazardType);
+}

--- a/QSB/Audio/Patches/PlayerAudioControllerPatches.cs
+++ b/QSB/Audio/Patches/PlayerAudioControllerPatches.cs
@@ -33,4 +33,20 @@ internal class PlayerAudioControllerPatches : QSBPatch
 	[HarmonyPostfix]
 	[HarmonyPatch(typeof(PlayerAudioController), nameof(PlayerAudioController.PlayRefuel))]
 	public static void PlayerAudioController_PlayRefuel() => PlayOneShot(AudioType.ShipCabinUseRefueller);
+
+	[HarmonyPostfix]
+	[HarmonyPatch(typeof(PlayerAudioController), nameof(PlayerAudioController.OnArtifactFocus))]
+	public static void PlayerAudioController_OnArtifactFocus() => PlayOneShot(AudioType.Artifact_Focus);
+
+	[HarmonyPostfix]
+	[HarmonyPatch(typeof(PlayerAudioController), nameof(PlayerAudioController.OnArtifactUnfocus))]
+	public static void PlayerAudioController_OnArtifactUnfocus() => PlayOneShot(AudioType.Artifact_Unfocus);
+
+	[HarmonyPostfix]
+	[HarmonyPatch(typeof(PlayerAudioController), nameof(PlayerAudioController.OnArtifactConceal))]
+	public static void PlayerAudioController_OnArtifactConceal() => PlayOneShot(AudioType.Artifact_Conceal);
+
+	[HarmonyPostfix]
+	[HarmonyPatch(typeof(PlayerAudioController), nameof(PlayerAudioController.OnArtifactUnconceal))]
+	public static void PlayerAudioController_OnArtifactUnconceal() => PlayOneShot(AudioType.Artifact_Unconceal);
 }

--- a/QSB/Audio/Patches/PlayerAudioControllerPatches.cs
+++ b/QSB/Audio/Patches/PlayerAudioControllerPatches.cs
@@ -3,6 +3,7 @@ using QSB.Audio.Messages;
 using QSB.Messaging;
 using QSB.Patches;
 using QSB.Player;
+using UnityEngine;
 
 namespace QSB.Audio.Patches;
 
@@ -49,4 +50,15 @@ internal class PlayerAudioControllerPatches : QSBPatch
 	[HarmonyPostfix]
 	[HarmonyPatch(typeof(PlayerAudioController), nameof(PlayerAudioController.OnArtifactUnconceal))]
 	public static void PlayerAudioController_OnArtifactUnconceal() => PlayOneShot(AudioType.Artifact_Unconceal);
+
+	[HarmonyPrefix]
+	[HarmonyPatch(typeof(PlayerAudioController), nameof(PlayerAudioController.UpdateHazardDamage))]
+	public static void PlayerAudioController_UpdateHazardDamage(PlayerAudioController __instance, float damage, HazardDetector hazardDetector)
+	{
+		var hazardType = damage > 0f ? hazardDetector.GetLatestHazardType() : HazardVolume.HazardType.NONE;
+		if (hazardType != __instance._hazardTypePlaying)
+		{
+			new PlayerAudioControllerUpdateHazardDamageMessage((QSBPlayerManager.LocalPlayerId, hazardDetector.GetLatestHazardType())).Send();
+		}
+	}
 }

--- a/QSB/Audio/QSBPlayerAudioController.cs
+++ b/QSB/Audio/QSBPlayerAudioController.cs
@@ -17,7 +17,7 @@ public class QSBPlayerAudioController : MonoBehaviour
 	{
 		_audioManager = Locator.GetAudioManager();
 
-		// This should be done in the Unity project
+		// TODO: This should be done in the Unity project
 		var damageAudio = new GameObject("DamageAudioSource");
 		damageAudio.SetActive(false);
 		damageAudio.transform.SetParent(transform, false);

--- a/QSB/Audio/QSBPlayerAudioController.cs
+++ b/QSB/Audio/QSBPlayerAudioController.cs
@@ -1,4 +1,5 @@
-﻿using QSB.Utility;
+﻿using QSB.PlayerBodySetup.Remote;
+using QSB.Utility;
 using UnityEngine;
 
 namespace QSB.Audio;
@@ -8,6 +9,26 @@ public class QSBPlayerAudioController : MonoBehaviour
 {
 	public OWAudioSource _oneShotExternalSource;
 	public OWAudioSource _repairToolSource;
+	public OWAudioSource _damageAudioSource;
+
+	private AudioManager _audioManager;
+
+	public void Start()
+	{
+		_audioManager = Locator.GetAudioManager();
+
+		// This should be done in the Unity project
+		var damageAudio = new GameObject("DamageAudioSource");
+		damageAudio.SetActive(false);
+		damageAudio.transform.SetParent(transform, false);
+		damageAudio.transform.localPosition = Vector3.zero;
+		_damageAudioSource = damageAudio.AddComponent<OWAudioSource>();
+		_damageAudioSource._audioSource = damageAudio.GetAddComponent<AudioSource>();
+		_damageAudioSource.SetTrack(_repairToolSource.GetTrack());
+		_damageAudioSource.spatialBlend = 1f;
+		_damageAudioSource.gameObject.GetAddComponent<QSBDopplerFixer>();
+		damageAudio.SetActive(true);
+	}
 
 	public void PlayEquipTool()
 		=> _oneShotExternalSource?.PlayOneShot(AudioType.ToolTranslatorEquip);
@@ -41,4 +62,41 @@ public class QSBPlayerAudioController : MonoBehaviour
 
 	public void OnJump(float pitch) =>
 		PlayOneShot(AudioType.MovementJump, pitch, 0.7f);
+
+	private void StartHazardDamage(HazardVolume.HazardType latestHazardType)
+	{
+		var type = AudioType.EnterVolumeDamageHeat_LP;
+		if (latestHazardType == HazardVolume.HazardType.DARKMATTER)
+		{
+			type = AudioType.EnterVolumeDamageGhostfire_LP;
+		}
+		else if (latestHazardType == HazardVolume.HazardType.FIRE)
+		{
+			type = AudioType.EnterVolumeDamageFire_LP;
+		}
+
+		_damageAudioSource.clip = _audioManager.GetSingleAudioClip(type, true);
+		_damageAudioSource.Stop();
+		_damageAudioSource.FadeIn(0.2f, true, true, 1f);
+	}
+
+	private void EndHazardDamage()
+	{
+		if (_damageAudioSource.isPlaying)
+		{
+			_damageAudioSource.FadeOut(0.5f, OWAudioSource.FadeOutCompleteAction.STOP, 0f);
+		}
+	}
+
+	public void SetHazardDamage(HazardVolume.HazardType latestHazardType)
+	{
+		if (latestHazardType == HazardVolume.HazardType.NONE)
+		{
+			EndHazardDamage();
+		}
+		else
+		{
+			StartHazardDamage(latestHazardType);
+		}
+	}
 }

--- a/QSB/EchoesOfTheEye/DreamLantern/DreamLanternManager.cs
+++ b/QSB/EchoesOfTheEye/DreamLantern/DreamLanternManager.cs
@@ -11,5 +11,5 @@ public class DreamLanternManager : WorldObjectManager
 	public override bool DlcOnly => true;
 
 	public override async UniTask BuildWorldObjects(OWScene scene, CancellationToken ct) =>
-		QSBWorldSync.Init<QSBDreamLantern, DreamLanternController>();
+		QSBWorldSync.Init<QSBDreamLanternController, DreamLanternController>();
 }

--- a/QSB/EchoesOfTheEye/DreamLantern/Messages/SetConcealedMessage.cs
+++ b/QSB/EchoesOfTheEye/DreamLantern/Messages/SetConcealedMessage.cs
@@ -3,10 +3,10 @@ using QSB.Messaging;
 
 namespace QSB.EchoesOfTheEye.DreamLantern.Messages;
 
-internal class SetConcealedMessage : QSBWorldObjectMessage<QSBDreamLantern, bool>
+internal class SetConcealedMessage : QSBWorldObjectMessage<QSBDreamLanternController, bool>
 {
 	public SetConcealedMessage(bool concealed) : base(concealed) { }
 
-	public override void OnReceiveRemote()
-		=> WorldObject.AttachedObject.SetConcealed(Data);
+	public override void OnReceiveRemote() =>
+		WorldObject.AttachedObject.SetConcealed(Data);
 }

--- a/QSB/EchoesOfTheEye/DreamLantern/Messages/SetFocusMessage.cs
+++ b/QSB/EchoesOfTheEye/DreamLantern/Messages/SetFocusMessage.cs
@@ -3,7 +3,7 @@ using QSB.Messaging;
 
 namespace QSB.EchoesOfTheEye.DreamLantern.Messages;
 
-internal class SetFocusMessage : QSBWorldObjectMessage<QSBDreamLantern, float>
+internal class SetFocusMessage : QSBWorldObjectMessage<QSBDreamLanternController, float>
 {
 	public SetFocusMessage(float focus) : base(focus) { }
 

--- a/QSB/EchoesOfTheEye/DreamLantern/Messages/SetLitMessage.cs
+++ b/QSB/EchoesOfTheEye/DreamLantern/Messages/SetLitMessage.cs
@@ -1,12 +1,16 @@
 ﻿using QSB.EchoesOfTheEye.DreamLantern.WorldObjects;
 using QSB.Messaging;
+using System.Collections.Generic;
 
 namespace QSB.EchoesOfTheEye.DreamLantern.Messages;
 
-internal class SetLitMessage : QSBWorldObjectMessage<QSBDreamLantern, bool>
+internal class SetLitMessage : QSBWorldObjectMessage<QSBDreamLanternController, bool>
 {
 	public SetLitMessage(bool lit) : base(lit) { }
 
 	public override void OnReceiveRemote()
-		=> WorldObject.AttachedObject.SetLit(Data);
+	{
+		WorldObject.AttachedObject.SetLit(Data);
+		WorldObject.DreamLanternItem._oneShotSource.PlayOneShot(Data ? AudioType.Artifact_Light : AudioType.Artifact_Extinguish, 1f);
+	}
 }

--- a/QSB/EchoesOfTheEye/DreamLantern/Messages/SetLitMessage.cs
+++ b/QSB/EchoesOfTheEye/DreamLantern/Messages/SetLitMessage.cs
@@ -1,6 +1,5 @@
 ﻿using QSB.EchoesOfTheEye.DreamLantern.WorldObjects;
 using QSB.Messaging;
-using System.Collections.Generic;
 
 namespace QSB.EchoesOfTheEye.DreamLantern.Messages;
 
@@ -12,5 +11,11 @@ internal class SetLitMessage : QSBWorldObjectMessage<QSBDreamLanternController, 
 	{
 		WorldObject.AttachedObject.SetLit(Data);
 		WorldObject.DreamLanternItem?._oneShotSource?.PlayOneShot(Data ? AudioType.Artifact_Light : AudioType.Artifact_Extinguish, 1f);
+
+		// If a lantern is already lit you shouldn't be able to pick it up
+		if (Data)
+		{
+			WorldObject.DreamLanternItem.EnableInteraction(false);
+		}
 	}
 }

--- a/QSB/EchoesOfTheEye/DreamLantern/Messages/SetLitMessage.cs
+++ b/QSB/EchoesOfTheEye/DreamLantern/Messages/SetLitMessage.cs
@@ -11,6 +11,6 @@ internal class SetLitMessage : QSBWorldObjectMessage<QSBDreamLanternController, 
 	public override void OnReceiveRemote()
 	{
 		WorldObject.AttachedObject.SetLit(Data);
-		WorldObject.DreamLanternItem._oneShotSource.PlayOneShot(Data ? AudioType.Artifact_Light : AudioType.Artifact_Extinguish, 1f);
+		WorldObject.DreamLanternItem?._oneShotSource?.PlayOneShot(Data ? AudioType.Artifact_Light : AudioType.Artifact_Extinguish, 1f);
 	}
 }

--- a/QSB/EchoesOfTheEye/DreamLantern/Messages/SetRangeMessage.cs
+++ b/QSB/EchoesOfTheEye/DreamLantern/Messages/SetRangeMessage.cs
@@ -3,7 +3,7 @@ using QSB.Messaging;
 
 namespace QSB.EchoesOfTheEye.DreamLantern.Messages;
 
-internal class SetRangeMessage : QSBWorldObjectMessage<QSBDreamLantern, (float minRange, float maxRange)>
+internal class SetRangeMessage : QSBWorldObjectMessage<QSBDreamLanternController, (float minRange, float maxRange)>
 {
 	public SetRangeMessage(float minRange, float maxRange) : base((minRange, maxRange)) { }
 

--- a/QSB/EchoesOfTheEye/DreamLantern/Patches/DreamLanternPatches.cs
+++ b/QSB/EchoesOfTheEye/DreamLantern/Patches/DreamLanternPatches.cs
@@ -31,7 +31,7 @@ internal class DreamLanternPatches : QSBPatch
 			return;
 		}
 
-		var qsbDreamLantern = __instance.GetWorldObject<QSBDreamLantern>();
+		var qsbDreamLantern = __instance.GetWorldObject<QSBDreamLanternController>();
 		// ghost lanterns should only be controlled by the host
 		if (qsbDreamLantern.IsGhostLantern && !QSBCore.IsHost)
 		{
@@ -59,7 +59,7 @@ internal class DreamLanternPatches : QSBPatch
 			return;
 		}
 
-		var qsbDreamLantern = __instance.GetWorldObject<QSBDreamLantern>();
+		var qsbDreamLantern = __instance.GetWorldObject<QSBDreamLanternController>();
 		// ghost lanterns should only be controlled by the host
 		if (qsbDreamLantern.IsGhostLantern && !QSBCore.IsHost)
 		{
@@ -88,7 +88,7 @@ internal class DreamLanternPatches : QSBPatch
 			return;
 		}
 
-		var qsbDreamLantern = __instance.GetWorldObject<QSBDreamLantern>();
+		var qsbDreamLantern = __instance.GetWorldObject<QSBDreamLanternController>();
 		// ghost lanterns should only be controlled by the host
 		if (qsbDreamLantern.IsGhostLantern && !QSBCore.IsHost)
 		{
@@ -116,7 +116,7 @@ internal class DreamLanternPatches : QSBPatch
 			return;
 		}
 
-		var qsbDreamLantern = __instance.GetWorldObject<QSBDreamLantern>();
+		var qsbDreamLantern = __instance.GetWorldObject<QSBDreamLanternController>();
 		// ghost lanterns should only be controlled by the host
 		if (qsbDreamLantern.IsGhostLantern && !QSBCore.IsHost)
 		{

--- a/QSB/EchoesOfTheEye/DreamLantern/WorldObjects/QSBDreamLanternController.cs
+++ b/QSB/EchoesOfTheEye/DreamLantern/WorldObjects/QSBDreamLanternController.cs
@@ -1,11 +1,26 @@
-﻿using QSB.EchoesOfTheEye.DreamLantern.Messages;
+﻿using Cysharp.Threading.Tasks;
+using QSB.EchoesOfTheEye.DreamLantern.Messages;
 using QSB.Messaging;
 using QSB.WorldSync;
+using System.Threading;
 
 namespace QSB.EchoesOfTheEye.DreamLantern.WorldObjects;
 
-public class QSBDreamLantern : WorldObject<DreamLanternController>
+public class QSBDreamLanternController : WorldObject<DreamLanternController>
 {
+	public DreamLanternItem DreamLanternItem { get; private set; }
+
+	public override async UniTask Init(CancellationToken ct)
+	{
+		await base.Init(ct);
+
+		// Ghosts don't have the item and instead the effects are controlled by GhostEffects
+		if (!IsGhostLantern)
+		{
+			DreamLanternItem = AttachedObject.GetComponent<DreamLanternItem>();
+		}
+	}
+
 	public override void SendInitialState(uint to)
 	{
 		this.SendMessage(new SetLitMessage(AttachedObject._lit) { To = to });

--- a/QSB/EchoesOfTheEye/LightSensorSync/Messages/IlluminatingLanternsMessage.cs
+++ b/QSB/EchoesOfTheEye/LightSensorSync/Messages/IlluminatingLanternsMessage.cs
@@ -10,12 +10,12 @@ namespace QSB.EchoesOfTheEye.LightSensorSync.Messages;
 internal class IlluminatingLanternsMessage : QSBWorldObjectMessage<QSBLightSensor, int[]>
 {
 	public IlluminatingLanternsMessage(IEnumerable<DreamLanternController> lanterns) :
-		base(lanterns.Select(x => x.GetWorldObject<QSBDreamLantern>().ObjectId).ToArray()) { }
+		base(lanterns.Select(x => x.GetWorldObject<QSBDreamLanternController>().ObjectId).ToArray()) { }
 
 	public override void OnReceiveRemote()
 	{
 		WorldObject.AttachedObject._illuminatingDreamLanternList.Clear();
 		WorldObject.AttachedObject._illuminatingDreamLanternList.AddRange(
-			Data.Select(x => x.GetWorldObject<QSBDreamLantern>().AttachedObject));
+			Data.Select(x => x.GetWorldObject<QSBDreamLanternController>().AttachedObject));
 	}
 }

--- a/QSB/EchoesOfTheEye/LightSensorSync/Messages/PlayerIlluminatingLanternsMessage.cs
+++ b/QSB/EchoesOfTheEye/LightSensorSync/Messages/PlayerIlluminatingLanternsMessage.cs
@@ -12,7 +12,7 @@ internal class PlayerIlluminatingLanternsMessage : QSBMessage<(uint playerId, in
 	public PlayerIlluminatingLanternsMessage(uint playerId, IEnumerable<DreamLanternController> lanterns) :
 		base((
 			playerId,
-			lanterns.Select(x => x.GetWorldObject<QSBDreamLantern>().ObjectId).ToArray()
+			lanterns.Select(x => x.GetWorldObject<QSBDreamLanternController>().ObjectId).ToArray()
 		)) { }
 
 	public override void OnReceiveRemote()
@@ -21,6 +21,6 @@ internal class PlayerIlluminatingLanternsMessage : QSBMessage<(uint playerId, in
 
 		lightSensor._illuminatingDreamLanternList.Clear();
 		lightSensor._illuminatingDreamLanternList.AddRange(
-			Data.lanterns.Select(x => x.GetWorldObject<QSBDreamLantern>().AttachedObject));
+			Data.lanterns.Select(x => x.GetWorldObject<QSBDreamLanternController>().AttachedObject));
 	}
 }

--- a/QSB/ItemSync/WorldObjects/Items/QSBDreamLanternItem.cs
+++ b/QSB/ItemSync/WorldObjects/Items/QSBDreamLanternItem.cs
@@ -56,5 +56,10 @@ public class QSBDreamLanternItem : QSBItem<DreamLanternItem>
 
 			AttachedObject.gameObject.transform.localScale = Vector3.one;
 		}
+
+		// If in the DreamWorld, don't let other people pick up your lantern
+		// Since this method is only called on the remote, this only makes other players unable to pick it up
+		// If the lantern is lit, the user is in the DreamWorld
+		AttachedObject.EnableInteraction(!AttachedObject.GetLanternController().IsLit());
 	}
 }

--- a/QSB/ItemSync/WorldObjects/Items/QSBDreamLanternItem.cs
+++ b/QSB/ItemSync/WorldObjects/Items/QSBDreamLanternItem.cs
@@ -1,3 +1,60 @@
-﻿namespace QSB.ItemSync.WorldObjects.Items;
+﻿using Cysharp.Threading.Tasks;
+using System.Linq;
+using System.Threading;
+using UnityEngine;
 
-public class QSBDreamLanternItem : QSBItem<DreamLanternItem> { }
+namespace QSB.ItemSync.WorldObjects.Items;
+
+public class QSBDreamLanternItem : QSBItem<DreamLanternItem> 
+{
+	private Material[] _materials;
+
+	public override async UniTask Init(CancellationToken ct)
+	{
+		await base.Init(ct);
+
+		// Some lanterns (ie, nonfunctioning) don't have a view model group
+		if (AttachedObject._lanternType != DreamLanternType.Nonfunctioning)
+		{
+			_materials = AttachedObject._lanternController._viewModelGroup?.GetComponentsInChildren<MeshRenderer>(true)?.SelectMany(x => x.materials)?.ToArray();
+		}
+	}
+
+	public override void PickUpItem(Transform holdTransform)
+	{
+		base.PickUpItem(holdTransform);
+
+		// Fixes #502: Artifact is visible through the walls
+		if (AttachedObject._lanternType != DreamLanternType.Nonfunctioning)
+		{
+			foreach (Material m in _materials)
+			{
+				if (m.renderQueue >= 2000)
+				{
+					m.renderQueue -= 2000;
+				}
+			}
+
+			// The view model looks much smaller than the dropped item
+			AttachedObject.gameObject.transform.localScale = Vector3.one * 2f;
+		}
+	}
+
+	public override void DropItem(Vector3 worldPosition, Vector3 worldNormal, Transform parent, Sector sector, IItemDropTarget customDropTarget)
+	{
+		base.DropItem(worldPosition, worldNormal, parent, sector, customDropTarget);
+
+		if (AttachedObject._lanternType != DreamLanternType.Nonfunctioning)
+		{
+			foreach (Material m in _materials)
+			{
+				if (m.renderQueue < 2000)
+				{
+					m.renderQueue += 2000;
+				}
+			}
+
+			AttachedObject.gameObject.transform.localScale = Vector3.one;
+		}
+	}
+}

--- a/QSB/ItemSync/WorldObjects/Items/QSBItem.cs
+++ b/QSB/ItemSync/WorldObjects/Items/QSBItem.cs
@@ -114,10 +114,10 @@ public class QSBItem<T> : WorldObject<T>, IQSBItem
 
 	public ItemType GetItemType() => AttachedObject.GetItemType();
 
-	public void PickUpItem(Transform holdTransform) =>
+	public virtual void PickUpItem(Transform holdTransform) =>
 		AttachedObject.PickUpItem(holdTransform);
 
-	public void DropItem(Vector3 worldPosition, Vector3 worldNormal, Transform parent, Sector sector, IItemDropTarget customDropTarget) =>
+	public virtual void DropItem(Vector3 worldPosition, Vector3 worldNormal, Transform parent, Sector sector, IItemDropTarget customDropTarget) =>
 		AttachedObject.DropItem(worldPosition, worldNormal, parent, sector, customDropTarget);
 
 	public void OnCompleteUnsocket() => AttachedObject.OnCompleteUnsocket();

--- a/QSB/ItemSync/WorldObjects/Sockets/QSBItemSocket.cs
+++ b/QSB/ItemSync/WorldObjects/Sockets/QSBItemSocket.cs
@@ -13,8 +13,18 @@ internal class QSBItemSocket : WorldObject<OWItemSocket>
 	public bool IsSocketOccupied() => AttachedObject.IsSocketOccupied();
 
 	public void PlaceIntoSocket(IQSBItem item)
-		=> AttachedObject.PlaceIntoSocket((OWItem)item.AttachedObject);
+	{
+		AttachedObject.PlaceIntoSocket((OWItem)item.AttachedObject);
+
+		// Don't let other users unsocket a DreamLantern in the dreamworld that doesn't belong to them
+		// DreamLanternSockets only exist in the DreamWorld
+		AttachedObject.EnableInteraction(AttachedObject is not DreamLanternSocket);
+	}
 
 	public void RemoveFromSocket()
-		=> AttachedObject.RemoveFromSocket();
+	{
+		AttachedObject.RemoveFromSocket();
+
+		AttachedObject.EnableInteraction(true);
+	}
 }

--- a/QSB/Utility/DebugActions.cs
+++ b/QSB/Utility/DebugActions.cs
@@ -167,7 +167,8 @@ public class DebugActions : MonoBehaviour, IAddComponentOnStart
 				{
 					var dreamLanternItem = QSBWorldSync.GetWorldObjects<QSBDreamLanternItem>().First(x =>
 						x.AttachedObject._lanternType == DreamLanternType.Functioning &&
-						QSBPlayerManager.PlayerList.All(y => y.HeldItem != x)
+						QSBPlayerManager.PlayerList.All(y => y.HeldItem != x) &&
+						(!x.AttachedObject.GetLanternController()?.IsLit() ?? false)
 					).AttachedObject;
 					Locator.GetToolModeSwapper().GetItemCarryTool().PickUpItemInstantly(dreamLanternItem);
 				}


### PR DESCRIPTION
- Fixes #502
- Synced HazardVolume sounds (ex, catching fire) and DreamLaternItem sounds (focusing, concealing, lighting)
- Prevent other players from stealing your DreamLantern (includes initial state sync, and when using Debug Q+2 command)

I also renamed QSBDreamLantern to QSBDreamLanternController to distinguish between it and QSBDreamLanternItem