### PR TITLE
0.30.0

### DIFF
--- a/APITestMod/APITestMod.cs
+++ b/APITestMod/APITestMod.cs
@@ -1,0 +1,50 @@
+﻿using OWML.ModHelper;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace APITestMod;
+
+public class APITestMod : ModBehaviour
+{
+	public void Start()
+	{
+		var qsbAPI = ModHelper.Interaction.TryGetModApi<IQSBAPI>("Raicuparta.QuantumSpaceBuddies");
+		var menuFrameworkAPI = ModHelper.Interaction.TryGetModApi<IMenuAPI>("_nebula.MenuFramework");
+
+		LoadManager.OnCompleteSceneLoad += (oldScene, newScene) =>
+		{
+			if (newScene != OWScene.SolarSystem)
+			{
+				return;
+			}
+
+			var button = menuFrameworkAPI.PauseMenu_MakeSimpleButton("QSB Api Test");
+
+			button.onClick.AddListener(() =>
+			{
+				ModHelper.Console.WriteLine("TESTING QSB API!");
+
+				ModHelper.Console.WriteLine($"Local Player ID : {qsbAPI.GetLocalPlayerID()}");
+
+				ModHelper.Console.WriteLine("Setting custom data as \"QSB TEST STRING\"");
+				qsbAPI.SetCustomData(qsbAPI.GetLocalPlayerID(), "APITEST.TESTSTRING", "QSB TEST STRING");
+				ModHelper.Console.WriteLine($"Retreiving custom data : {qsbAPI.GetCustomData<string>(qsbAPI.GetLocalPlayerID(), "APITEST.TESTSTRING")}");
+
+				ModHelper.Console.WriteLine("Sending string message test...");
+				qsbAPI.RegisterHandler<string>("apitest-string", MessageHandler);
+				qsbAPI.SendMessage("apitest-string", "STRING MESSAGE", true);
+
+				ModHelper.Console.WriteLine("Sending int message test...");
+				qsbAPI.RegisterHandler<int>("apitest-int", MessageHandler);
+				qsbAPI.SendMessage("apitest-int", 123, true);
+
+				ModHelper.Console.WriteLine("Sending float message test...");
+				qsbAPI.RegisterHandler<float>("apitest-float", MessageHandler);
+				qsbAPI.SendMessage("apitest-float", 3.14f, true);
+			});
+		};
+	}
+
+	private void MessageHandler<T>(uint from, T data)
+		=> ModHelper.Console.WriteLine($"Got : {data}");
+}

--- a/APITestMod/APITestMod.cs
+++ b/APITestMod/APITestMod.cs
@@ -1,4 +1,5 @@
-﻿using OWML.ModHelper;
+﻿using OWML.Common;
+using OWML.ModHelper;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -20,11 +21,21 @@ public class APITestMod : ModBehaviour
 
 			var button = menuFrameworkAPI.PauseMenu_MakeSimpleButton("QSB Api Test");
 
+			qsbAPI.OnPlayerJoin().AddListener((uint playerId) => ModHelper.Console.WriteLine($"{playerId} joined the game!", MessageType.Success));
+			qsbAPI.OnPlayerLeave().AddListener((uint playerId) => ModHelper.Console.WriteLine($"{playerId} left the game!", MessageType.Success));
+
 			button.onClick.AddListener(() =>
 			{
 				ModHelper.Console.WriteLine("TESTING QSB API!");
 
 				ModHelper.Console.WriteLine($"Local Player ID : {qsbAPI.GetLocalPlayerID()}");
+
+				ModHelper.Console.WriteLine("Player IDs :");
+
+				foreach (var playerID in qsbAPI.GetPlayerIDs())
+				{
+					ModHelper.Console.WriteLine($" - id:{playerID} name:{qsbAPI.GetPlayerName(playerID)}");
+				}
 
 				ModHelper.Console.WriteLine("Setting custom data as \"QSB TEST STRING\"");
 				qsbAPI.SetCustomData(qsbAPI.GetLocalPlayerID(), "APITEST.TESTSTRING", "QSB TEST STRING");

--- a/APITestMod/APITestMod.csproj
+++ b/APITestMod/APITestMod.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="OuterWildsGameLibs" Version="1.1.13.457" IncludeAssets="compile" />
-    <PackageReference Include="OWML" Version="2.9.4" IncludeAssets="compile" />
+    <PackageReference Include="OWML" Version="2.9.5" IncludeAssets="compile" />
   </ItemGroup>
 
   <ItemGroup>

--- a/APITestMod/APITestMod.csproj
+++ b/APITestMod/APITestMod.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <RootNamespace>APITestMod</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputPath Condition="Exists('$(OwmlDir)')">$(OwmlDir)\Mods\_nebula.QSBAPITest</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OuterWildsGameLibs" Version="1.1.13.457" IncludeAssets="compile" />
+    <PackageReference Include="OWML" Version="2.9.4" IncludeAssets="compile" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="manifest.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/APITestMod/IMenuAPI.cs
+++ b/APITestMod/IMenuAPI.cs
@@ -1,0 +1,23 @@
+﻿using UnityEngine;
+using UnityEngine.UI;
+
+namespace APITestMod;
+
+public interface IMenuAPI
+{
+	// Title screen
+	GameObject TitleScreen_MakeMenuOpenButton(string name, int index, Menu menuToOpen);
+	GameObject TitleScreen_MakeSceneLoadButton(string name, int index, SubmitActionLoadScene.LoadableScenes sceneToLoad, PopupMenu confirmPopup = null);
+	Button TitleScreen_MakeSimpleButton(string name, int index);
+	// Pause menu
+	GameObject PauseMenu_MakeMenuOpenButton(string name, Menu menuToOpen, Menu customMenu = null);
+	GameObject PauseMenu_MakeSceneLoadButton(string name, SubmitActionLoadScene.LoadableScenes sceneToLoad, PopupMenu confirmPopup = null, Menu customMenu = null);
+	Button PauseMenu_MakeSimpleButton(string name, Menu customMenu = null);
+	Menu PauseMenu_MakePauseListMenu(string title);
+	// Misc
+	PopupMenu MakeTwoChoicePopup(string message, string confirmText, string cancelText);
+	PopupInputMenu MakeInputFieldPopup(string message, string placeholderMessage, string confirmText, string cancelText);
+	PopupMenu MakeInfoPopup(string message, string continueButtonText);
+	// Startup Popups
+	void RegisterStartupPopup(string message);
+}

--- a/APITestMod/IQSBAPI.cs
+++ b/APITestMod/IQSBAPI.cs
@@ -1,10 +1,13 @@
-﻿using System;
+﻿using OWML.Common;
 using UnityEngine.Events;
-
-namespace APITestMod;
 
 public interface IQSBAPI
 {
+	/// <summary>
+	/// If called, all players connected to YOUR hosted game must have this mod installed.
+	/// </summary>
+	void RegisterRequiredForAllPlayers(IModBehaviour mod);
+
 	/// <summary>
 	/// Returns the player ID of the current player.
 	/// </summary>

--- a/APITestMod/IQSBAPI.cs
+++ b/APITestMod/IQSBAPI.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace APITestMod;
+
+// TODO: document
+public interface IQSBAPI
+{
+	uint GetLocalPlayerID();
+
+	void SetCustomData<T>(uint playerId, string key, T data);
+	T GetCustomData<T>(uint playerId, string key);
+
+	void SendMessage<T>(string messageType, T data, bool receiveLocally = false);
+	void RegisterHandler<T>(string messageType, Action<uint, T> handler);
+}

--- a/APITestMod/IQSBAPI.cs
+++ b/APITestMod/IQSBAPI.cs
@@ -1,15 +1,68 @@
 ﻿using System;
+using UnityEngine.Events;
 
 namespace APITestMod;
 
-// TODO: document
 public interface IQSBAPI
 {
+	/// <summary>
+	/// Returns the player ID of the current player.
+	/// </summary>
 	uint GetLocalPlayerID();
 
+	/// <summary>
+	/// Returns the name of a given player.
+	/// </summary>
+	/// <param name="playerID">The ID of the player you want the name of.</param>
+	string GetPlayerName(uint playerID);
+
+	/// <summary>
+	/// Returns the list of IDs of all connected players.
+	/// </summary>
+	uint[] GetPlayerIDs();
+
+	/// <summary>
+	/// Invoked when a player joins the game.
+	/// </summary>
+	UnityEvent<uint> OnPlayerJoin();
+
+	/// <summary>
+	/// Invoked when a player leaves the game.
+	/// </summary>
+	UnityEvent<uint> OnPlayerLeave();
+
+	/// <summary>
+	/// Sets some arbitrary data for a given player.
+	/// </summary>
+	/// <typeparam name="T">The type of the data.</typeparam>
+	/// <param name="playerId">The ID of the player.</param>
+	/// <param name="key">The unique key to access this data by.</param>
+	/// <param name="data">The data to set.</param>
 	void SetCustomData<T>(uint playerId, string key, T data);
+
+	/// <summary>
+	/// Returns some arbitrary data from a given player.
+	/// </summary>
+	/// <typeparam name="T">The type of the data.</typeparam>
+	/// <param name="playerId">The ID of the player.</param>
+	/// <param name="key">The unique key of the data you want to access.</param>
+	/// <returns>The data requested. If key is not valid, returns default.</returns>
 	T GetCustomData<T>(uint playerId, string key);
 
+	/// <summary>
+	/// Sends a message containing arbitrary data to every player.
+	/// </summary>
+	/// <typeparam name="T">The type of the data being sent. This type must be serializable.</typeparam>
+	/// <param name="messageType">The unique key of the message.</param>
+	/// <param name="data">The data to send.</param>
+	/// <param name="receiveLocally">If true, the action given to <see cref="RegisterHandler{T}"/> will also be called on the same client that is sending the message.</param>
 	void SendMessage<T>(string messageType, T data, bool receiveLocally = false);
+
+	/// <summary>
+	/// Registers an action to be called when a message is received.
+	/// </summary>
+	/// <typeparam name="T">The type of the data in the message.</typeparam>
+	/// <param name="messageType">The unique key of the message.</param>
+	/// <param name="handler">The action to be ran when the message is received. The uint is the player ID that sent the messsage.</param>
 	void RegisterHandler<T>(string messageType, Action<uint, T> handler);
 }

--- a/APITestMod/manifest.json
+++ b/APITestMod/manifest.json
@@ -1,0 +1,9 @@
+{
+  "filename": "APITestMod.dll",
+  "author": "_nebula",
+  "name": "QSB API Test Mod",
+  "uniqueName": "_nebula.QSBAPITest",
+  "version": "1.0.0",
+  "owmlVersion": "2.9.4",
+  "dependencies": [ "Raicuparta.QuantumSpaceBuddies", "_nebula.MenuFramework" ]
+}

--- a/APITestMod/manifest.json
+++ b/APITestMod/manifest.json
@@ -4,6 +4,6 @@
   "name": "QSB API Test Mod",
   "uniqueName": "_nebula.QSBAPITest",
   "version": "1.0.0",
-  "owmlVersion": "2.9.4",
+  "owmlVersion": "2.9.5",
   "dependencies": [ "Raicuparta.QuantumSpaceBuddies", "_nebula.MenuFramework" ]
 }

--- a/EpicRerouter/EpicRerouter.csproj
+++ b/EpicRerouter/EpicRerouter.csproj
@@ -15,6 +15,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="OuterWildsGameLibs" Version="1.1.13.457" IncludeAssets="compile" />
-    <PackageReference Include="OWML" Version="2.9.4" IncludeAssets="compile" />
+    <PackageReference Include="OWML" Version="2.9.5" IncludeAssets="compile" />
   </ItemGroup>
 </Project>

--- a/MirrorWeaver/MirrorWeaver.csproj
+++ b/MirrorWeaver/MirrorWeaver.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="OuterWildsGameLibs" Version="1.1.13.457" />
-    <PackageReference Include="OWML" Version="2.9.4" />
+    <PackageReference Include="OWML" Version="2.9.5" />
     <Reference Include="../Mirror/*.dll" />
   </ItemGroup>
   <ItemGroup>

--- a/QSB.sln
+++ b/QSB.sln
@@ -20,6 +20,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EpicOnlineTransport", "Epic
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EpicRerouter", "EpicRerouter\EpicRerouter.csproj", "{639EFAEE-C4A1-4DA2-8457-D0472A9F6343}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "APITestMod", "APITestMod\APITestMod.csproj", "{0A10143E-6C00-409B-B3A5-C54C1B01599D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -42,6 +44,10 @@ Global
 		{639EFAEE-C4A1-4DA2-8457-D0472A9F6343}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{639EFAEE-C4A1-4DA2-8457-D0472A9F6343}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{639EFAEE-C4A1-4DA2-8457-D0472A9F6343}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0A10143E-6C00-409B-B3A5-C54C1B01599D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0A10143E-6C00-409B-B3A5-C54C1B01599D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0A10143E-6C00-409B-B3A5-C54C1B01599D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0A10143E-6C00-409B-B3A5-C54C1B01599D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/QSB.sln.DotSettings
+++ b/QSB.sln.DotSettings
@@ -9,6 +9,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_WHILE/@EntryValue">Required</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/CASE_BLOCK_BRACES/@EntryValue">NEXT_LINE_SHIFTED_2</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=QSB/@EntryIndexedValue">QSB</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UWP/@EntryIndexedValue">UWP</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>

--- a/QSB/API/AddonDataManager.cs
+++ b/QSB/API/AddonDataManager.cs
@@ -6,22 +6,22 @@ namespace QSB.API;
 
 public static class AddonDataManager
 {
-	private static readonly Dictionary<string, Action<object>> _handlers = new();
+	private static readonly Dictionary<string, Action<uint, object>> _handlers = new();
 
-	public static void OnReceiveDataMessage(string messageType, object data)
+	public static void OnReceiveDataMessage(string messageType, object data, uint from)
 	{
-		DebugLog.DebugWrite($"Received data message of message type \"{messageType}\"!");
+		DebugLog.DebugWrite($"Received data message of message type \"{messageType}\" from {from}!");
 		if (!_handlers.TryGetValue(messageType, out var handler))
 		{
 			return;
 		}
 
-		handler(data);
+		handler(from, data);
 	}
 
-	public static void RegisterHandler<T>(string messageType, Action<T> handler)
+	public static void RegisterHandler<T>(string messageType, Action<uint, T> handler)
 	{
 		DebugLog.DebugWrite($"Registering handler for \"{messageType}\" with type of {typeof(T).Name}");
-		_handlers.Add(messageType, data => handler((T)data));
+		_handlers.Add(messageType, (from, data) => handler(from, (T)data));
 	}
 }

--- a/QSB/API/IQSBAPI.cs
+++ b/QSB/API/IQSBAPI.cs
@@ -1,15 +1,68 @@
 ﻿using System;
+using UnityEngine.Events;
 
 namespace QSB.API;
 
-// TODO: document
 public interface IQSBAPI
 {
+	/// <summary>
+	/// Returns the player ID of the current player.
+	/// </summary>
 	uint GetLocalPlayerID();
 
+	/// <summary>
+	/// Returns the name of a given player.
+	/// </summary>
+	/// <param name="playerID">The ID of the player you want the name of.</param>
+	string GetPlayerName(uint playerID);
+
+	/// <summary>
+	/// Returns the list of IDs of all connected players.
+	/// </summary>
+	uint[] GetPlayerIDs();
+
+	/// <summary>
+	/// Invoked when a player joins the game.
+	/// </summary>
+	UnityEvent<uint> OnPlayerJoin();
+
+	/// <summary>
+	/// Invoked when a player leaves the game.
+	/// </summary>
+	UnityEvent<uint> OnPlayerLeave();
+
+	/// <summary>
+	/// Sets some arbitrary data for a given player.
+	/// </summary>
+	/// <typeparam name="T">The type of the data.</typeparam>
+	/// <param name="playerId">The ID of the player.</param>
+	/// <param name="key">The unique key to access this data by.</param>
+	/// <param name="data">The data to set.</param>
 	void SetCustomData<T>(uint playerId, string key, T data);
+
+	/// <summary>
+	/// Returns some arbitrary data from a given player.
+	/// </summary>
+	/// <typeparam name="T">The type of the data.</typeparam>
+	/// <param name="playerId">The ID of the player.</param>
+	/// <param name="key">The unique key of the data you want to access.</param>
+	/// <returns>The data requested. If key is not valid, returns default.</returns>
 	T GetCustomData<T>(uint playerId, string key);
 
+	/// <summary>
+	/// Sends a message containing arbitrary data to every player.
+	/// </summary>
+	/// <typeparam name="T">The type of the data being sent. This type must be serializable.</typeparam>
+	/// <param name="messageType">The unique key of the message.</param>
+	/// <param name="data">The data to send.</param>
+	/// <param name="receiveLocally">If true, the action given to <see cref="RegisterHandler{T}"/> will also be called on the same client that is sending the message.</param>
 	void SendMessage<T>(string messageType, T data, bool receiveLocally = false);
+
+	/// <summary>
+	/// Registers an action to be called when a message is received.
+	/// </summary>
+	/// <typeparam name="T">The type of the data in the message.</typeparam>
+	/// <param name="messageType">The unique key of the message.</param>
+	/// <param name="handler">The action to be ran when the message is received. The uint is the player ID that sent the messsage.</param>
 	void RegisterHandler<T>(string messageType, Action<uint, T> handler);
 }

--- a/QSB/API/IQSBAPI.cs
+++ b/QSB/API/IQSBAPI.cs
@@ -1,10 +1,14 @@
 ﻿using System;
+using OWML.Common;
 using UnityEngine.Events;
-
-namespace QSB.API;
 
 public interface IQSBAPI
 {
+	/// <summary>
+	/// If called, all players connected to YOUR hosted game must have this mod installed.
+	/// </summary>
+	void RegisterRequiredForAllPlayers(IModBehaviour mod);
+
 	/// <summary>
 	/// Returns the player ID of the current player.
 	/// </summary>

--- a/QSB/API/IQSBAPI.cs
+++ b/QSB/API/IQSBAPI.cs
@@ -10,6 +10,6 @@ public interface IQSBAPI
 	void SetCustomData<T>(uint playerId, string key, T data);
 	T GetCustomData<T>(uint playerId, string key);
 
-	void SendMessage<T>(string messageType, T data);
-	void RegisterHandler<T>(string messageType, Action<T> handler);
+	void SendMessage<T>(string messageType, T data, bool receiveLocally = false);
+	void RegisterHandler<T>(string messageType, Action<uint, T> handler);
 }

--- a/QSB/API/Messages/AddonDataMessage.cs
+++ b/QSB/API/Messages/AddonDataMessage.cs
@@ -4,9 +4,9 @@ using QSB.Messaging;
 
 namespace QSB.API.Messages;
 
-public class AddonDataMessage : QSBMessage<(string messageType, byte[] data)>
+public class AddonDataMessage : QSBMessage<(string messageType, byte[] data, bool receiveLocally)>
 {
-	public AddonDataMessage(string messageType, object data) : base((messageType, Obj2Bytes(data))) { }
+	public AddonDataMessage(string messageType, object data, bool receiveLocally) : base((messageType, Obj2Bytes(data), receiveLocally)) { }
 
 	private static byte[] Obj2Bytes(object obj)
 	{
@@ -25,9 +25,17 @@ public class AddonDataMessage : QSBMessage<(string messageType, byte[] data)>
 		return obj;
 	}
 
+	public override void OnReceiveLocal()
+	{
+		if (Data.receiveLocally)
+		{
+			OnReceiveRemote();
+		}
+	}
+
 	public override void OnReceiveRemote()
 	{
 		var obj = Bytes2Obj(Data.data);
-		AddonDataManager.OnReceiveDataMessage(Data.messageType, obj);
+		AddonDataManager.OnReceiveDataMessage(Data.messageType, obj, From);
 	}
 }

--- a/QSB/API/QSBAPI.cs
+++ b/QSB/API/QSBAPI.cs
@@ -42,9 +42,7 @@ internal static class QSBAPIEvents
 		QSBPlayerManager.OnRemovePlayer += player => OnPlayerLeaveEvent.Invoke(player.PlayerId);
 	}
 
-	public static UnityEvent<uint> OnPlayerJoinEvent = new PlayerEvent();
-	public static UnityEvent<uint> OnPlayerLeaveEvent = new PlayerEvent();
+	internal class PlayerEvent : UnityEvent<uint> { }
+	internal static PlayerEvent OnPlayerJoinEvent = new PlayerEvent();
+	internal static PlayerEvent OnPlayerLeaveEvent = new PlayerEvent();
 }
-
-// i hate OOP sometimes
-internal class PlayerEvent : UnityEvent<uint> { }

--- a/QSB/API/QSBAPI.cs
+++ b/QSB/API/QSBAPI.cs
@@ -1,24 +1,43 @@
 ﻿using System;
+using System.Linq;
 using QSB.API.Messages;
 using QSB.Messaging;
 using QSB.Player;
+using UnityEngine.Events;
 
 namespace QSB.API;
 
 public class QSBAPI : IQSBAPI
 {
 	public uint GetLocalPlayerID() => QSBPlayerManager.LocalPlayerId;
+	public string GetPlayerName(uint playerId) => QSBPlayerManager.GetPlayer(playerId).Name;
+	public uint[] GetPlayerIDs() => QSBPlayerManager.PlayerList.Select(x => x.PlayerId).ToArray();
+
+	public UnityEvent<uint> OnPlayerJoin() => QSBAPIEvents.OnPlayerJoinEvent;
+
+	public UnityEvent<uint> OnPlayerLeave() => QSBAPIEvents.OnPlayerLeaveEvent;
 
 	public void SetCustomData<T>(uint playerId, string key, T data) => QSBPlayerManager.GetPlayer(playerId).SetCustomData(key, data);
 	public T GetCustomData<T>(uint playerId, string key) => QSBPlayerManager.GetPlayer(playerId).GetCustomData<T>(key);
 
 	public void SendMessage<T>(string messageType, T data, bool receiveLocally = false)
-	{
-		new AddonDataMessage(messageType, data, receiveLocally).Send();
-	}
+		=> new AddonDataMessage(messageType, data, receiveLocally).Send();
 
 	public void RegisterHandler<T>(string messageType, Action<uint, T> handler)
-	{
-		AddonDataManager.RegisterHandler(messageType, handler);
-	}
+		=> AddonDataManager.RegisterHandler(messageType, handler);
 }
+
+internal static class QSBAPIEvents
+{
+	static QSBAPIEvents()
+	{
+		QSBPlayerManager.OnAddPlayer += player => OnPlayerJoinEvent.Invoke(player.PlayerId);
+		QSBPlayerManager.OnRemovePlayer += player => OnPlayerLeaveEvent.Invoke(player.PlayerId);
+	}
+
+	public static UnityEvent<uint> OnPlayerJoinEvent = new PlayerEvent();
+	public static UnityEvent<uint> OnPlayerLeaveEvent = new PlayerEvent();
+}
+
+// i hate OOP sometimes
+internal class PlayerEvent : UnityEvent<uint> { }

--- a/QSB/API/QSBAPI.cs
+++ b/QSB/API/QSBAPI.cs
@@ -12,12 +12,12 @@ public class QSBAPI : IQSBAPI
 	public void SetCustomData<T>(uint playerId, string key, T data) => QSBPlayerManager.GetPlayer(playerId).SetCustomData(key, data);
 	public T GetCustomData<T>(uint playerId, string key) => QSBPlayerManager.GetPlayer(playerId).GetCustomData<T>(key);
 
-	public void SendMessage<T>(string messageType, T data)
+	public void SendMessage<T>(string messageType, T data, bool receiveLocally = false)
 	{
-		new AddonDataMessage(messageType, data).Send();
+		new AddonDataMessage(messageType, data, receiveLocally).Send();
 	}
 
-	public void RegisterHandler<T>(string messageType, Action<T> handler)
+	public void RegisterHandler<T>(string messageType, Action<uint, T> handler)
 	{
 		AddonDataManager.RegisterHandler(messageType, handler);
 	}

--- a/QSB/API/QSBAPI.cs
+++ b/QSB/API/QSBAPI.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using OWML.Common;
 using QSB.API.Messages;
 using QSB.Messaging;
 using QSB.Player;
@@ -9,6 +10,12 @@ namespace QSB.API;
 
 public class QSBAPI : IQSBAPI
 {
+	public void RegisterRequiredForAllPlayers(IModBehaviour mod)
+	{
+		var uniqueName = mod.ModHelper.Manifest.UniqueName;
+		QSBCore.Addons.Add(uniqueName, mod);
+	}
+
 	public uint GetLocalPlayerID() => QSBPlayerManager.LocalPlayerId;
 	public string GetPlayerName(uint playerId) => QSBPlayerManager.GetPlayer(playerId).Name;
 	public uint[] GetPlayerIDs() => QSBPlayerManager.PlayerList.Select(x => x.PlayerId).ToArray();

--- a/QSB/Animation/NPC/CharacterAnimManager.cs
+++ b/QSB/Animation/NPC/CharacterAnimManager.cs
@@ -5,7 +5,7 @@ using System.Threading;
 
 namespace QSB.Animation.NPC;
 
-internal class CharacterAnimManager : WorldObjectManager
+public class CharacterAnimManager : WorldObjectManager
 {
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.Both;
 

--- a/QSB/Animation/NPC/Patches/TravelerControllerPatches.cs
+++ b/QSB/Animation/NPC/Patches/TravelerControllerPatches.cs
@@ -108,7 +108,7 @@ public class TravelerControllerPatches : QSBPatch
 	}
 }
 
-internal static class TravelerAudioManagerExtensions
+public static class TravelerAudioManagerExtensions
 {
 	/// bad, but works great
 	private static SignalName? TravelerToSignalName(TravelerController traveler)

--- a/QSB/Animation/NPC/WorldObjects/QSBSolanumAnimController.cs
+++ b/QSB/Animation/NPC/WorldObjects/QSBSolanumAnimController.cs
@@ -7,7 +7,7 @@ namespace QSB.Animation.NPC.WorldObjects;
 /// <summary>
 /// only used to get QSBSolanumTrigger from SolanumAnimController
 /// </summary>
-internal class QSBSolanumAnimController : WorldObject<SolanumAnimController>
+public class QSBSolanumAnimController : WorldObject<SolanumAnimController>
 {
 	private QSBSolanumTrigger _trigger;
 	public QSBSolanumTrigger Trigger => _trigger ??= QSBWorldSync.GetWorldObjects<QSBSolanumTrigger>().First();

--- a/QSB/Animation/Player/Thrusters/RemoteThrusterFlameController.cs
+++ b/QSB/Animation/Player/Thrusters/RemoteThrusterFlameController.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace QSB.Animation.Player.Thrusters;
 
 [UsedInUnityProject]
-internal class RemoteThrusterFlameController : MonoBehaviour
+public class RemoteThrusterFlameController : MonoBehaviour
 {
 	[SerializeField]
 	private Thruster _thruster;

--- a/QSB/Animation/Player/Thrusters/RemoteThrusterParticlesBehaviour.cs
+++ b/QSB/Animation/Player/Thrusters/RemoteThrusterParticlesBehaviour.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace QSB.Animation.Player.Thrusters;
 
 [UsedInUnityProject]
-internal class RemoteThrusterParticlesBehaviour : MonoBehaviour
+public class RemoteThrusterParticlesBehaviour : MonoBehaviour
 {
 	[SerializeField]
 	private Thruster _thruster;

--- a/QSB/Animation/Player/Thrusters/RemoteThrusterWashController.cs
+++ b/QSB/Animation/Player/Thrusters/RemoteThrusterWashController.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace QSB.Animation.Player.Thrusters;
 
 [UsedInUnityProject]
-internal class RemoteThrusterWashController : MonoBehaviour
+public class RemoteThrusterWashController : MonoBehaviour
 {
 	[SerializeField]
 	private float _raycastDistance = 10f;

--- a/QSB/Animation/Player/Thrusters/ThrusterManager.cs
+++ b/QSB/Animation/Player/Thrusters/ThrusterManager.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace QSB.Animation.Player.Thrusters;
 
-internal static class ThrusterManager
+public static class ThrusterManager
 {
 	public static void CreateRemotePlayerVFX(PlayerInfo player)
 	{

--- a/QSB/Audio/Messages/PlayerAudioControllerUpdateHazardDamageMessage.cs
+++ b/QSB/Audio/Messages/PlayerAudioControllerUpdateHazardDamageMessage.cs
@@ -3,7 +3,7 @@ using QSB.Player;
 
 namespace QSB.Audio.Messages;
 
-internal class PlayerAudioControllerUpdateHazardDamageMessage : QSBMessage<(uint userID, HazardVolume.HazardType latestHazardType)>
+public class PlayerAudioControllerUpdateHazardDamageMessage : QSBMessage<(uint userID, HazardVolume.HazardType latestHazardType)>
 {
 	public PlayerAudioControllerUpdateHazardDamageMessage((uint userID, HazardVolume.HazardType latestHazardType) data) : base(data) { }
 

--- a/QSB/Audio/Patches/PlayerAudioControllerPatches.cs
+++ b/QSB/Audio/Patches/PlayerAudioControllerPatches.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 namespace QSB.Audio.Patches;
 
 [HarmonyPatch]
-internal class PlayerAudioControllerPatches : QSBPatch
+public class PlayerAudioControllerPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/Audio/Patches/PlayerImpactAudioPatches.cs
+++ b/QSB/Audio/Patches/PlayerImpactAudioPatches.cs
@@ -6,7 +6,7 @@ using QSB.Player;
 
 namespace QSB.Audio.Patches;
 
-internal class PlayerImpactAudioPatches : QSBPatch
+public class PlayerImpactAudioPatches : QSBPatch
 {
 	// Since we patch Start we do it when the mod starts, else it won't run
 	public override QSBPatchTypes Type => QSBPatchTypes.OnModStart;

--- a/QSB/Audio/Patches/PlayerMovementAudioPatches.cs
+++ b/QSB/Audio/Patches/PlayerMovementAudioPatches.cs
@@ -6,7 +6,7 @@ using QSB.Player;
 
 namespace QSB.Audio.Patches;
 
-internal class PlayerMovementAudioPatches : QSBPatch
+public class PlayerMovementAudioPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/Audio/Patches/ThrusterAudioPatches.cs
+++ b/QSB/Audio/Patches/ThrusterAudioPatches.cs
@@ -5,7 +5,7 @@ using QSB.Patches;
 
 namespace QSB.Audio.Patches;
 
-internal class ThrusterAudioPatches : QSBPatch
+public class ThrusterAudioPatches : QSBPatch
 {
 	// Since we patch Start we do it when the mod starts, else it won't run
 	public override QSBPatchTypes Type => QSBPatchTypes.OnModStart;

--- a/QSB/Audio/QSBAudioSourceOneShotTracker.cs
+++ b/QSB/Audio/QSBAudioSourceOneShotTracker.cs
@@ -31,7 +31,7 @@ public class QSBAudioSourceOneShotTracker : MonoBehaviour
 }
 
 [HarmonyPatch(typeof(OWAudioSource))]
-internal class OneShotTrackerPatches : QSBPatch
+public class OneShotTrackerPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/Audio/QSBJetpackThrusterAudio.cs
+++ b/QSB/Audio/QSBJetpackThrusterAudio.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace QSB.Audio;
 
 [UsedInUnityProject]
-internal class QSBJetpackThrusterAudio : QSBThrusterAudio
+public class QSBJetpackThrusterAudio : QSBThrusterAudio
 {
 	public OWAudioSource _underwaterSource;
 	public OWAudioSource _oxygenSource;

--- a/QSB/Audio/QSBThrusterAudio.cs
+++ b/QSB/Audio/QSBThrusterAudio.cs
@@ -2,7 +2,7 @@
 
 namespace QSB.Audio;
 
-internal class QSBThrusterAudio : MonoBehaviour
+public class QSBThrusterAudio : MonoBehaviour
 {
 	public OWAudioSource _translationalSource;
 	public OWAudioSource _rotationalSource;

--- a/QSB/CampfireSync/CampfireManager.cs
+++ b/QSB/CampfireSync/CampfireManager.cs
@@ -5,7 +5,7 @@ using System.Threading;
 
 namespace QSB.CampfireSync;
 
-internal class CampfireManager : WorldObjectManager
+public class CampfireManager : WorldObjectManager
 {
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.Both;
 

--- a/QSB/CampfireSync/Messages/BurnSlideReelMessage.cs
+++ b/QSB/CampfireSync/Messages/BurnSlideReelMessage.cs
@@ -9,7 +9,7 @@ namespace QSB.CampfireSync.Messages;
 /// <summary>
 /// TODO: initial state on campfire and item
 /// </summary>
-internal class BurnSlideReelMessage : QSBWorldObjectMessage<QSBSlideReelItem, int>
+public class BurnSlideReelMessage : QSBWorldObjectMessage<QSBSlideReelItem, int>
 {
 	public BurnSlideReelMessage(QSBCampfire campfire) : base(campfire.ObjectId) { }
 

--- a/QSB/CampfireSync/Messages/CampfireStateMessage.cs
+++ b/QSB/CampfireSync/Messages/CampfireStateMessage.cs
@@ -3,7 +3,7 @@ using QSB.Messaging;
 
 namespace QSB.CampfireSync.Messages;
 
-internal class CampfireStateMessage : QSBWorldObjectMessage<QSBCampfire, Campfire.State>
+public class CampfireStateMessage : QSBWorldObjectMessage<QSBCampfire, Campfire.State>
 {
 	public CampfireStateMessage(Campfire.State state) : base(state) { }
 

--- a/QSB/CampfireSync/Patches/CampfirePatches.cs
+++ b/QSB/CampfireSync/Patches/CampfirePatches.cs
@@ -10,7 +10,7 @@ using UnityEngine;
 namespace QSB.CampfireSync.Patches;
 
 [HarmonyPatch]
-internal class CampfirePatches : QSBPatch
+public class CampfirePatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/ClientServerStateSync/ClientStateManager.cs
+++ b/QSB/ClientServerStateSync/ClientStateManager.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 
 namespace QSB.ClientServerStateSync;
 
-internal class ClientStateManager : MonoBehaviour
+public class ClientStateManager : MonoBehaviour
 {
 	public static ClientStateManager Instance { get; private set; }
 

--- a/QSB/ClientServerStateSync/Messages/ClientStateMessage.cs
+++ b/QSB/ClientServerStateSync/Messages/ClientStateMessage.cs
@@ -8,7 +8,7 @@ namespace QSB.ClientServerStateSync.Messages;
 /// <summary>
 /// sets the state both locally and remotely
 /// </summary>
-internal class ClientStateMessage : QSBMessage<ClientState>
+public class ClientStateMessage : QSBMessage<ClientState>
 {
 	public ClientStateMessage(ClientState state) : base(state) { }
 

--- a/QSB/ClientServerStateSync/Messages/ServerStateMessage.cs
+++ b/QSB/ClientServerStateSync/Messages/ServerStateMessage.cs
@@ -5,7 +5,7 @@ namespace QSB.ClientServerStateSync.Messages;
 /// <summary>
 /// sets the state both locally and remotely
 /// </summary>
-internal class ServerStateMessage : QSBMessage<ServerState>
+public class ServerStateMessage : QSBMessage<ServerState>
 {
 	public ServerStateMessage(ServerState state) : base(state) { }
 

--- a/QSB/ClientServerStateSync/ServerStateManager.cs
+++ b/QSB/ClientServerStateSync/ServerStateManager.cs
@@ -10,7 +10,7 @@ using UnityEngine;
 
 namespace QSB.ClientServerStateSync;
 
-internal class ServerStateManager : MonoBehaviour
+public class ServerStateManager : MonoBehaviour
 {
 	public static ServerStateManager Instance { get; private set; }
 

--- a/QSB/ConversationSync/Messages/EnterRemoteDialogueMessage.cs
+++ b/QSB/ConversationSync/Messages/EnterRemoteDialogueMessage.cs
@@ -3,7 +3,7 @@ using QSB.Messaging;
 
 namespace QSB.ConversationSync.Messages;
 
-internal class EnterRemoteDialogueMessage : QSBWorldObjectMessage<QSBRemoteDialogueTrigger, int>
+public class EnterRemoteDialogueMessage : QSBWorldObjectMessage<QSBRemoteDialogueTrigger, int>
 {
 	public EnterRemoteDialogueMessage(int dialogueIndex) : base(dialogueIndex) { }
 

--- a/QSB/ConversationSync/Messages/PersistentConditionMessage.cs
+++ b/QSB/ConversationSync/Messages/PersistentConditionMessage.cs
@@ -3,7 +3,7 @@ using QSB.WorldSync;
 
 namespace QSB.ConversationSync.Messages;
 
-internal class PersistentConditionMessage : QSBMessage<(string Condition, bool State)>
+public class PersistentConditionMessage : QSBMessage<(string Condition, bool State)>
 {
 	public PersistentConditionMessage(string condition, bool state) : base((condition, state)) { }
 

--- a/QSB/ConversationSync/Messages/RemoteDialogueInitialStateMessage.cs
+++ b/QSB/ConversationSync/Messages/RemoteDialogueInitialStateMessage.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace QSB.ConversationSync.Messages;
 
-internal class RemoteDialogueInitialStateMessage : QSBWorldObjectMessage<QSBRemoteDialogueTrigger>
+public class RemoteDialogueInitialStateMessage : QSBWorldObjectMessage<QSBRemoteDialogueTrigger>
 {
 	private bool _inRemoteDialogue;
 	private bool[] _activatedDialogues;

--- a/QSB/ConversationSync/WorldObjects/QSBRemoteDialogueTrigger.cs
+++ b/QSB/ConversationSync/WorldObjects/QSBRemoteDialogueTrigger.cs
@@ -4,7 +4,7 @@ using QSB.WorldSync;
 
 namespace QSB.ConversationSync.WorldObjects;
 
-internal class QSBRemoteDialogueTrigger : WorldObject<RemoteDialogueTrigger>
+public class QSBRemoteDialogueTrigger : WorldObject<RemoteDialogueTrigger>
 {
 	public override void SendInitialState(uint to) =>
 		this.SendMessage(new RemoteDialogueInitialStateMessage(AttachedObject) { To = to });

--- a/QSB/DeathSync/Messages/EndLoopMessage.cs
+++ b/QSB/DeathSync/Messages/EndLoopMessage.cs
@@ -7,7 +7,7 @@ using QSB.Utility;
 namespace QSB.DeathSync.Messages;
 
 // when all players die
-internal class EndLoopMessage : QSBMessage
+public class EndLoopMessage : QSBMessage
 {
 	public override void OnReceiveLocal() => OnReceiveRemote();
 

--- a/QSB/DeathSync/Messages/PlayerDeathMessage.cs
+++ b/QSB/DeathSync/Messages/PlayerDeathMessage.cs
@@ -42,7 +42,7 @@ public class PlayerDeathMessage : QSBMessage<DeathType>
 		var deathMessage = Necronomicon.GetPhrase(Data, NecronomiconIndex);
 		if (deathMessage != null)
 		{
-			MultiplayerHUDManager.Instance.WriteMessage(string.Format(deathMessage, playerName), Color.grey);
+			MultiplayerHUDManager.Instance.WriteSystemMessage(string.Format(deathMessage, playerName), Color.grey);
 		}
 
 		RespawnManager.Instance.OnPlayerDeath(player);

--- a/QSB/DeathSync/Messages/StartLoopMessage.cs
+++ b/QSB/DeathSync/Messages/StartLoopMessage.cs
@@ -6,7 +6,7 @@ using QSB.Utility;
 
 namespace QSB.DeathSync.Messages;
 
-internal class StartLoopMessage : QSBMessage
+public class StartLoopMessage : QSBMessage
 {
 	public override void OnReceiveLocal() => OnReceiveRemote();
 

--- a/QSB/DeathSync/Patches/MapPatches.cs
+++ b/QSB/DeathSync/Patches/MapPatches.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace QSB.DeathSync.Patches;
 
 [HarmonyPatch]
-internal class MapPatches : QSBPatch
+public class MapPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.RespawnTime;
 

--- a/QSB/EchoesOfTheEye/AirlockSync/AirlockManager.cs
+++ b/QSB/EchoesOfTheEye/AirlockSync/AirlockManager.cs
@@ -5,7 +5,7 @@ using System.Threading;
 
 namespace QSB.EchoesOfTheEye.AirlockSync;
 
-internal class AirlockManager : WorldObjectManager
+public class AirlockManager : WorldObjectManager
 {
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.SolarSystem;
 	public override bool DlcOnly => true;

--- a/QSB/EchoesOfTheEye/AirlockSync/Messages/AirlockCallToOpenMessage.cs
+++ b/QSB/EchoesOfTheEye/AirlockSync/Messages/AirlockCallToOpenMessage.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace QSB.EchoesOfTheEye.AirlockSync.Messages;
 
-internal class AirlockCallToOpenMessage : QSBWorldObjectMessage<QSBAirlockInterface, bool>
+public class AirlockCallToOpenMessage : QSBWorldObjectMessage<QSBAirlockInterface, bool>
 {
 	public AirlockCallToOpenMessage(bool front) : base(front) { }
 

--- a/QSB/EchoesOfTheEye/AirlockSync/Messages/AirlockInitialStateMessage.cs
+++ b/QSB/EchoesOfTheEye/AirlockSync/Messages/AirlockInitialStateMessage.cs
@@ -3,7 +3,7 @@ using QSB.Messaging;
 
 namespace QSB.EchoesOfTheEye.AirlockSync.Messages;
 
-internal class AirlockInitialStateMessage : QSBWorldObjectMessage<QSBGhostAirlock, (bool innerDoorOpen, bool outerDoorOpen, bool pressurized)>
+public class AirlockInitialStateMessage : QSBWorldObjectMessage<QSBGhostAirlock, (bool innerDoorOpen, bool outerDoorOpen, bool pressurized)>
 {
 	public AirlockInitialStateMessage(bool innerDoorOpen, bool outerDoorOpen, bool pressurized) : base((innerDoorOpen, outerDoorOpen, pressurized)) { }
 

--- a/QSB/EchoesOfTheEye/AirlockSync/Patches/AirlockPatches.cs
+++ b/QSB/EchoesOfTheEye/AirlockSync/Patches/AirlockPatches.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace QSB.EchoesOfTheEye.AirlockSync.Patches;
 
-internal class AirlockPatches : QSBPatch
+public class AirlockPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/EchoesOfTheEye/AirlockSync/VariableSync/AirlockVariableSyncer.cs
+++ b/QSB/EchoesOfTheEye/AirlockSync/VariableSync/AirlockVariableSyncer.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace QSB.EchoesOfTheEye.AirlockSync.VariableSync;
 
-internal class AirlockVariableSyncer : RotatingElementsVariableSyncer<QSBAirlockInterface>
+public class AirlockVariableSyncer : RotatingElementsVariableSyncer<QSBAirlockInterface>
 {
 	protected override Transform[] RotatingElements => WorldObject.AttachedObject._rotatingElements;
 

--- a/QSB/EchoesOfTheEye/AirlockSync/WorldObjects/QSBAirlockInterface.cs
+++ b/QSB/EchoesOfTheEye/AirlockSync/WorldObjects/QSBAirlockInterface.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace QSB.EchoesOfTheEye.AirlockSync.WorldObjects;
 
-internal class QSBAirlockInterface : QSBRotatingElements<AirlockInterface, AirlockVariableSyncer>
+public class QSBAirlockInterface : QSBRotatingElements<AirlockInterface, AirlockVariableSyncer>
 {
 	protected override IEnumerable<SingleLightSensor> LightSensors => AttachedObject._lightSensors;
 

--- a/QSB/EchoesOfTheEye/AirlockSync/WorldObjects/QSBGhostAirlock.cs
+++ b/QSB/EchoesOfTheEye/AirlockSync/WorldObjects/QSBGhostAirlock.cs
@@ -4,7 +4,7 @@ using QSB.WorldSync;
 
 namespace QSB.EchoesOfTheEye.AirlockSync.WorldObjects;
 
-internal class QSBGhostAirlock : WorldObject<GhostAirlock>
+public class QSBGhostAirlock : WorldObject<GhostAirlock>
 {
 	public override void SendInitialState(uint to)
 		=> this.SendMessage(

--- a/QSB/EchoesOfTheEye/DreamLantern/Messages/SetConcealedMessage.cs
+++ b/QSB/EchoesOfTheEye/DreamLantern/Messages/SetConcealedMessage.cs
@@ -3,7 +3,7 @@ using QSB.Messaging;
 
 namespace QSB.EchoesOfTheEye.DreamLantern.Messages;
 
-internal class SetConcealedMessage : QSBWorldObjectMessage<QSBDreamLanternController, bool>
+public class SetConcealedMessage : QSBWorldObjectMessage<QSBDreamLanternController, bool>
 {
 	public SetConcealedMessage(bool concealed) : base(concealed) { }
 

--- a/QSB/EchoesOfTheEye/DreamLantern/Messages/SetFocusMessage.cs
+++ b/QSB/EchoesOfTheEye/DreamLantern/Messages/SetFocusMessage.cs
@@ -3,7 +3,7 @@ using QSB.Messaging;
 
 namespace QSB.EchoesOfTheEye.DreamLantern.Messages;
 
-internal class SetFocusMessage : QSBWorldObjectMessage<QSBDreamLanternController, float>
+public class SetFocusMessage : QSBWorldObjectMessage<QSBDreamLanternController, float>
 {
 	public SetFocusMessage(float focus) : base(focus) { }
 

--- a/QSB/EchoesOfTheEye/DreamLantern/Messages/SetLitMessage.cs
+++ b/QSB/EchoesOfTheEye/DreamLantern/Messages/SetLitMessage.cs
@@ -3,7 +3,7 @@ using QSB.Messaging;
 
 namespace QSB.EchoesOfTheEye.DreamLantern.Messages;
 
-internal class SetLitMessage : QSBWorldObjectMessage<QSBDreamLanternController, bool>
+public class SetLitMessage : QSBWorldObjectMessage<QSBDreamLanternController, bool>
 {
 	public SetLitMessage(bool lit) : base(lit) { }
 

--- a/QSB/EchoesOfTheEye/DreamLantern/Messages/SetRangeMessage.cs
+++ b/QSB/EchoesOfTheEye/DreamLantern/Messages/SetRangeMessage.cs
@@ -3,7 +3,7 @@ using QSB.Messaging;
 
 namespace QSB.EchoesOfTheEye.DreamLantern.Messages;
 
-internal class SetRangeMessage : QSBWorldObjectMessage<QSBDreamLanternController, (float minRange, float maxRange)>
+public class SetRangeMessage : QSBWorldObjectMessage<QSBDreamLanternController, (float minRange, float maxRange)>
 {
 	public SetRangeMessage(float minRange, float maxRange) : base((minRange, maxRange)) { }
 

--- a/QSB/EchoesOfTheEye/DreamLantern/Patches/DreamLanternPatches.cs
+++ b/QSB/EchoesOfTheEye/DreamLantern/Patches/DreamLanternPatches.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace QSB.EchoesOfTheEye.DreamLantern.Patches;
 
-internal class DreamLanternPatches : QSBPatch
+public class DreamLanternPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/EchoesOfTheEye/DreamObjectProjectors/Messages/ProjectorLitMessage.cs
+++ b/QSB/EchoesOfTheEye/DreamObjectProjectors/Messages/ProjectorLitMessage.cs
@@ -3,7 +3,7 @@ using QSB.Messaging;
 
 namespace QSB.EchoesOfTheEye.DreamObjectProjectors.Messages;
 
-internal class ProjectorLitMessage : QSBWorldObjectMessage<QSBDreamObjectProjector, bool>
+public class ProjectorLitMessage : QSBWorldObjectMessage<QSBDreamObjectProjector, bool>
 {
 	public ProjectorLitMessage(bool lit) : base(lit) { }
 

--- a/QSB/EchoesOfTheEye/DreamObjectProjectors/Patches/ProjectorPatches.cs
+++ b/QSB/EchoesOfTheEye/DreamObjectProjectors/Patches/ProjectorPatches.cs
@@ -7,7 +7,7 @@ using QSB.WorldSync;
 
 namespace QSB.EchoesOfTheEye.DreamObjectProjectors.Patches;
 
-internal class ProjectorPatches : QSBPatch
+public class ProjectorPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/EchoesOfTheEye/DreamObjectProjectors/ProjectorManager.cs
+++ b/QSB/EchoesOfTheEye/DreamObjectProjectors/ProjectorManager.cs
@@ -5,7 +5,7 @@ using System.Threading;
 
 namespace QSB.EchoesOfTheEye.DreamObjectProjectors;
 
-internal class ProjectorManager : WorldObjectManager
+public class ProjectorManager : WorldObjectManager
 {
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.SolarSystem;
 	public override bool DlcOnly => true;

--- a/QSB/EchoesOfTheEye/DreamWorld/Messages/EnterDreamWorldMessage.cs
+++ b/QSB/EchoesOfTheEye/DreamWorld/Messages/EnterDreamWorldMessage.cs
@@ -11,7 +11,7 @@ namespace QSB.EchoesOfTheEye.DreamWorld.Messages;
 /// <summary>
 /// todo SendInitialState
 /// </summary>
-internal class EnterDreamWorldMessage : QSBWorldObjectMessage<QSBDreamLanternItem>
+public class EnterDreamWorldMessage : QSBWorldObjectMessage<QSBDreamLanternItem>
 {
 	static EnterDreamWorldMessage()
 	{

--- a/QSB/EchoesOfTheEye/DreamWorld/Messages/ExitDreamWorldMessage.cs
+++ b/QSB/EchoesOfTheEye/DreamWorld/Messages/ExitDreamWorldMessage.cs
@@ -9,7 +9,7 @@ namespace QSB.EchoesOfTheEye.DreamWorld.Messages;
 /// <summary>
 /// todo SendInitialState
 /// </summary>
-internal class ExitDreamWorldMessage : QSBMessage
+public class ExitDreamWorldMessage : QSBMessage
 {
 	static ExitDreamWorldMessage()
 	{

--- a/QSB/EchoesOfTheEye/EclipseCodeControllers/CodeControllerManager.cs
+++ b/QSB/EchoesOfTheEye/EclipseCodeControllers/CodeControllerManager.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace QSB.EchoesOfTheEye.EclipseCodeControllers;
 
-internal class CodeControllerManager : WorldObjectManager
+public class CodeControllerManager : WorldObjectManager
 {
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.SolarSystem;
 	public override bool DlcOnly => true;

--- a/QSB/EchoesOfTheEye/EclipseCodeControllers/CodeControllerRemoteUpdater.cs
+++ b/QSB/EchoesOfTheEye/EclipseCodeControllers/CodeControllerRemoteUpdater.cs
@@ -10,7 +10,7 @@ using UnityEngine;
 
 namespace QSB.EchoesOfTheEye.EclipseCodeControllers;
 
-internal class CodeControllerRemoteUpdater : MonoBehaviour
+public class CodeControllerRemoteUpdater : MonoBehaviour
 {
 	private QSBEclipseCodeController _attachedWorldObject;
 	private EclipseCodeController4 _codeController => _attachedWorldObject.AttachedObject;

--- a/QSB/EchoesOfTheEye/EclipseCodeControllers/Messages/InitialStateMessage.cs
+++ b/QSB/EchoesOfTheEye/EclipseCodeControllers/Messages/InitialStateMessage.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace QSB.EchoesOfTheEye.EclipseCodeControllers.Messages;
 
-internal class InitialStateMessage : QSBWorldObjectMessage<QSBEclipseCodeController>
+public class InitialStateMessage : QSBWorldObjectMessage<QSBEclipseCodeController>
 {
 	private int _selectedDial;
 	private int[] _dialSelectedSymbols;

--- a/QSB/EchoesOfTheEye/EclipseCodeControllers/Messages/MoveSelectorMessage.cs
+++ b/QSB/EchoesOfTheEye/EclipseCodeControllers/Messages/MoveSelectorMessage.cs
@@ -3,7 +3,7 @@ using QSB.Messaging;
 
 namespace QSB.EchoesOfTheEye.EclipseCodeControllers.Messages;
 
-internal class MoveSelectorMessage : QSBWorldObjectMessage<QSBEclipseCodeController, (int newSelectedDial, bool up)>
+public class MoveSelectorMessage : QSBWorldObjectMessage<QSBEclipseCodeController, (int newSelectedDial, bool up)>
 {
 	public MoveSelectorMessage(int selectedDial, bool up) : base((selectedDial, up)) { }
 

--- a/QSB/EchoesOfTheEye/EclipseCodeControllers/Messages/RotateDialMessage.cs
+++ b/QSB/EchoesOfTheEye/EclipseCodeControllers/Messages/RotateDialMessage.cs
@@ -4,7 +4,7 @@ using QSB.Utility;
 
 namespace QSB.EchoesOfTheEye.EclipseCodeControllers.Messages;
 
-internal class RotateDialMessage : QSBWorldObjectMessage<QSBEclipseCodeController, (bool right, int selectedDial)>
+public class RotateDialMessage : QSBWorldObjectMessage<QSBEclipseCodeController, (bool right, int selectedDial)>
 {
 	public RotateDialMessage(bool right, int selectedDial) : base((right, selectedDial)) { }
 

--- a/QSB/EchoesOfTheEye/EclipseCodeControllers/Patches/CodeControllerPatches.cs
+++ b/QSB/EchoesOfTheEye/EclipseCodeControllers/Patches/CodeControllerPatches.cs
@@ -13,7 +13,7 @@ using UnityEngine;
 
 namespace QSB.EchoesOfTheEye.EclipseCodeControllers.Patches;
 
-internal class CodeControllerPatches : QSBPatch
+public class CodeControllerPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/EchoesOfTheEye/EclipseDoors/DoorManager.cs
+++ b/QSB/EchoesOfTheEye/EclipseDoors/DoorManager.cs
@@ -5,7 +5,7 @@ using System.Threading;
 
 namespace QSB.EchoesOfTheEye.EclipseDoors;
 
-internal class DoorManager : WorldObjectManager
+public class DoorManager : WorldObjectManager
 {
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.SolarSystem;
 	public override bool DlcOnly => true;

--- a/QSB/EchoesOfTheEye/EclipseDoors/VariableSync/EclipseDoorVariableSyncer.cs
+++ b/QSB/EchoesOfTheEye/EclipseDoors/VariableSync/EclipseDoorVariableSyncer.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace QSB.EchoesOfTheEye.EclipseDoors.VariableSync;
 
-internal class EclipseDoorVariableSyncer : RotatingElementsVariableSyncer<QSBEclipseDoorController>
+public class EclipseDoorVariableSyncer : RotatingElementsVariableSyncer<QSBEclipseDoorController>
 {
 	protected override Transform[] RotatingElements => WorldObject.AttachedObject._rotatingElements;
 }

--- a/QSB/EchoesOfTheEye/EclipseDoors/WorldObjects/QSBEclipseDoorController.cs
+++ b/QSB/EchoesOfTheEye/EclipseDoors/WorldObjects/QSBEclipseDoorController.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace QSB.EchoesOfTheEye.EclipseDoors.WorldObjects;
 
-internal class QSBEclipseDoorController : QSBRotatingElements<EclipseDoorController, EclipseDoorVariableSyncer>
+public class QSBEclipseDoorController : QSBRotatingElements<EclipseDoorController, EclipseDoorVariableSyncer>
 {
 	protected override IEnumerable<SingleLightSensor> LightSensors => AttachedObject._lightSensors;
 

--- a/QSB/EchoesOfTheEye/EclipseElevators/EclipseElevatorManager.cs
+++ b/QSB/EchoesOfTheEye/EclipseElevators/EclipseElevatorManager.cs
@@ -5,7 +5,7 @@ using System.Threading;
 
 namespace QSB.EchoesOfTheEye.EclipseElevators;
 
-internal class EclipseElevatorManager : WorldObjectManager
+public class EclipseElevatorManager : WorldObjectManager
 {
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.SolarSystem;
 	public override bool DlcOnly => true;

--- a/QSB/EchoesOfTheEye/EclipseElevators/Messages/CallElevatorMessage.cs
+++ b/QSB/EchoesOfTheEye/EclipseElevators/Messages/CallElevatorMessage.cs
@@ -3,7 +3,7 @@ using QSB.Messaging;
 
 namespace QSB.EchoesOfTheEye.EclipseElevators.Messages;
 
-internal class CallElevatorMessage : QSBWorldObjectMessage<QSBElevatorDestination>
+public class CallElevatorMessage : QSBWorldObjectMessage<QSBElevatorDestination>
 {
 	public override void OnReceiveRemote()
 	{

--- a/QSB/EchoesOfTheEye/EclipseElevators/Patches/EclipseElevatorPatches.cs
+++ b/QSB/EchoesOfTheEye/EclipseElevators/Patches/EclipseElevatorPatches.cs
@@ -7,7 +7,7 @@ using QSB.WorldSync;
 
 namespace QSB.EchoesOfTheEye.EclipseElevators.Patches;
 
-internal class EclipseElevatorPatches : QSBPatch
+public class EclipseElevatorPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/EchoesOfTheEye/EclipseElevators/VariableSync/EclipseElevatorVariableSyncer.cs
+++ b/QSB/EchoesOfTheEye/EclipseElevators/VariableSync/EclipseElevatorVariableSyncer.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace QSB.EchoesOfTheEye.EclipseElevators.VariableSync;
 
-internal class EclipseElevatorVariableSyncer : RotatingElementsVariableSyncer<QSBEclipseElevatorController>
+public class EclipseElevatorVariableSyncer : RotatingElementsVariableSyncer<QSBEclipseElevatorController>
 {
 	protected override Transform[] RotatingElements => WorldObject.AttachedObject._rotatingElements;
 }

--- a/QSB/EchoesOfTheEye/EclipseElevators/WorldObjects/QSBEclipseElevatorController.cs
+++ b/QSB/EchoesOfTheEye/EclipseElevators/WorldObjects/QSBEclipseElevatorController.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace QSB.EchoesOfTheEye.EclipseElevators.WorldObjects;
 
-internal class QSBEclipseElevatorController : QSBRotatingElements<EclipseElevatorController, EclipseElevatorVariableSyncer>
+public class QSBEclipseElevatorController : QSBRotatingElements<EclipseElevatorController, EclipseElevatorVariableSyncer>
 {
 	protected override IEnumerable<SingleLightSensor> LightSensors => AttachedObject._lightSensors;
 

--- a/QSB/EchoesOfTheEye/EclipseElevators/WorldObjects/QSBElevatorDestination.cs
+++ b/QSB/EchoesOfTheEye/EclipseElevators/WorldObjects/QSBElevatorDestination.cs
@@ -2,7 +2,7 @@
 
 namespace QSB.EchoesOfTheEye.EclipseElevators.WorldObjects;
 
-internal class QSBElevatorDestination : WorldObject<ElevatorDestination>
+public class QSBElevatorDestination : WorldObject<ElevatorDestination>
 {
 	public override void SendInitialState(uint to)
 	{

--- a/QSB/EchoesOfTheEye/Ghosts/Actions/QSBChaseAction.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Actions/QSBChaseAction.cs
@@ -12,7 +12,7 @@ using UnityEngine;
 
 namespace QSB.EchoesOfTheEye.Ghosts.Actions;
 
-internal class QSBChaseAction : QSBGhostAction
+public class QSBChaseAction : QSBGhostAction
 {
 	private float _lastScreamTime;
 

--- a/QSB/EchoesOfTheEye/Ghosts/Actions/QSBGrabAction.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Actions/QSBGrabAction.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace QSB.EchoesOfTheEye.Ghosts.Actions;
 
-internal class QSBGrabAction : QSBGhostAction
+public class QSBGrabAction : QSBGhostAction
 {
 	private bool _playerIsGrabbed;
 	private bool _grabAnimComplete;

--- a/QSB/EchoesOfTheEye/Ghosts/GhostManager.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/GhostManager.cs
@@ -11,7 +11,7 @@ using UnityEngine;
 
 namespace QSB.EchoesOfTheEye.Ghosts;
 
-internal class GhostManager : WorldObjectManager
+public class GhostManager : WorldObjectManager
 {
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.SolarSystem;
 	public override bool DlcOnly => true;

--- a/QSB/EchoesOfTheEye/Ghosts/Messages/ChangeActionMessage.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Messages/ChangeActionMessage.cs
@@ -4,7 +4,7 @@ using QSB.Utility;
 
 namespace QSB.EchoesOfTheEye.Ghosts.Messages;
 
-internal class ChangeActionMessage : QSBWorldObjectMessage<QSBGhostBrain, GhostAction.Name>
+public class ChangeActionMessage : QSBWorldObjectMessage<QSBGhostBrain, GhostAction.Name>
 {
 	public ChangeActionMessage(GhostAction.Name name) : base(name) { }
 

--- a/QSB/EchoesOfTheEye/Ghosts/Messages/ChangeInterestedPlayerMessage.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Messages/ChangeInterestedPlayerMessage.cs
@@ -5,7 +5,7 @@ using QSB.Utility;
 
 namespace QSB.EchoesOfTheEye.Ghosts.Messages;
 
-internal class ChangeInterestedPlayerMessage : QSBWorldObjectMessage<QSBGhostSensors, uint>
+public class ChangeInterestedPlayerMessage : QSBWorldObjectMessage<QSBGhostSensors, uint>
 {
 	public ChangeInterestedPlayerMessage(uint playerId) : base(playerId) { }
 

--- a/QSB/EchoesOfTheEye/Ghosts/Messages/ChangeNodeMapMessage.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Messages/ChangeNodeMapMessage.cs
@@ -4,7 +4,7 @@ using QSB.WorldSync;
 
 namespace QSB.EchoesOfTheEye.Ghosts.Messages;
 
-internal class ChangeNodeMapMessage : QSBWorldObjectMessage<QSBGhostController, int>
+public class ChangeNodeMapMessage : QSBWorldObjectMessage<QSBGhostController, int>
 {
 	public ChangeNodeMapMessage(int nodeMapIndex) : base(nodeMapIndex) { }
 

--- a/QSB/EchoesOfTheEye/Ghosts/Messages/ContactTriggerMessage.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Messages/ContactTriggerMessage.cs
@@ -4,7 +4,7 @@ using QSB.Player;
 
 namespace QSB.EchoesOfTheEye.Ghosts.Messages;
 
-internal class ContactTriggerMessage : QSBWorldObjectMessage<QSBGhostSensors, bool>
+public class ContactTriggerMessage : QSBWorldObjectMessage<QSBGhostSensors, bool>
 {
 	public ContactTriggerMessage(bool inContact) : base(inContact) { }
 

--- a/QSB/EchoesOfTheEye/Ghosts/Messages/FaceLocalPositionMessage.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Messages/FaceLocalPositionMessage.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace QSB.EchoesOfTheEye.Ghosts.Messages;
 
-internal class FaceLocalPositionMessage : QSBWorldObjectMessage<QSBGhostController, (Vector3 localPosition, float degreesPerSecond, float turnAcceleration)>
+public class FaceLocalPositionMessage : QSBWorldObjectMessage<QSBGhostController, (Vector3 localPosition, float degreesPerSecond, float turnAcceleration)>
 {
 	public FaceLocalPositionMessage(Vector3 localPos, float degPerSecond, float turnAccel) : base((localPos, degPerSecond, turnAccel)) { }
 

--- a/QSB/EchoesOfTheEye/Ghosts/Messages/FaceNodeListMessage.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Messages/FaceNodeListMessage.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace QSB.EchoesOfTheEye.Ghosts.Messages;
 
-internal class FaceNodeListMessage : QSBWorldObjectMessage<QSBGhostController, (int mapId, int[] nodeIndexes, int numNodes, TurnSpeed turnSpeed, float nodeDelay, bool autoFocusLantern)>
+public class FaceNodeListMessage : QSBWorldObjectMessage<QSBGhostController, (int mapId, int[] nodeIndexes, int numNodes, TurnSpeed turnSpeed, float nodeDelay, bool autoFocusLantern)>
 {
 	public FaceNodeListMessage(GhostNode[] nodeList, int numNodes, TurnSpeed turnSpeed, float nodeDelay, bool autoFocus) : base(Process(nodeList, numNodes, turnSpeed, nodeDelay, autoFocus)) { }
 

--- a/QSB/EchoesOfTheEye/Ghosts/Messages/FaceNodeMessage.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Messages/FaceNodeMessage.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace QSB.EchoesOfTheEye.Ghosts.Messages;
 
-internal class FaceNodeMessage : QSBWorldObjectMessage<QSBGhostController, (int mapId, int nodeIndex, TurnSpeed turnSpeed, float nodeDelay, bool autoFocusLantern)>
+public class FaceNodeMessage : QSBWorldObjectMessage<QSBGhostController, (int mapId, int nodeIndex, TurnSpeed turnSpeed, float nodeDelay, bool autoFocusLantern)>
 {
 	public FaceNodeMessage(GhostNode node, TurnSpeed turnSpeed, float nodeDelay, bool autoFocusLantern) : base(Process(node, turnSpeed, nodeDelay, autoFocusLantern)) { }
 

--- a/QSB/EchoesOfTheEye/Ghosts/Messages/FacePlayerMessage.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Messages/FacePlayerMessage.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace QSB.EchoesOfTheEye.Ghosts.Messages;
 
-internal class FacePlayerMessage : QSBWorldObjectMessage<QSBGhostController, (uint playerId, TurnSpeed turnSpeed)>
+public class FacePlayerMessage : QSBWorldObjectMessage<QSBGhostController, (uint playerId, TurnSpeed turnSpeed)>
 {
 	public FacePlayerMessage(uint playerId, TurnSpeed turnSpeed) : base((playerId, turnSpeed)) { }
 

--- a/QSB/EchoesOfTheEye/Ghosts/Messages/FaceVelocityMessage.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Messages/FaceVelocityMessage.cs
@@ -4,7 +4,7 @@ using QSB.Utility;
 
 namespace QSB.EchoesOfTheEye.Ghosts.Messages;
 
-internal class FaceVelocityMessage : QSBWorldObjectMessage<QSBGhostController>
+public class FaceVelocityMessage : QSBWorldObjectMessage<QSBGhostController>
 {
 	public override void OnReceiveRemote()
 	{

--- a/QSB/EchoesOfTheEye/Ghosts/Messages/GhostAnimationTriggerMessage.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Messages/GhostAnimationTriggerMessage.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace QSB.EchoesOfTheEye.Ghosts.Messages;
 
-internal class GhostAnimationTriggerMessage : QSBWorldObjectMessage<QSBGhostEffects, GhostAnimationType>
+public class GhostAnimationTriggerMessage : QSBWorldObjectMessage<QSBGhostEffects, GhostAnimationType>
 {
 	public GhostAnimationTriggerMessage(GhostAnimationType type) : base(type) { }
 

--- a/QSB/EchoesOfTheEye/Ghosts/Messages/GrabRemotePlayerMessage.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Messages/GrabRemotePlayerMessage.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace QSB.EchoesOfTheEye.Ghosts.Messages;
 
-internal class GrabRemotePlayerMessage : QSBWorldObjectMessage<QSBGhostGrabController, (float speed, uint playerId)>
+public class GrabRemotePlayerMessage : QSBWorldObjectMessage<QSBGhostGrabController, (float speed, uint playerId)>
 {
 	public GrabRemotePlayerMessage(float speed, uint playerId) : base((speed, playerId)) { }
 

--- a/QSB/EchoesOfTheEye/Ghosts/Messages/MoveToLocalPositionMessage.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Messages/MoveToLocalPositionMessage.cs
@@ -10,7 +10,7 @@ using UnityEngine;
 
 namespace QSB.EchoesOfTheEye.Ghosts.Messages;
 
-internal class MoveToLocalPositionMessage : QSBWorldObjectMessage<QSBGhostController, (Vector3 localPosition, float speed, float acceleration)>
+public class MoveToLocalPositionMessage : QSBWorldObjectMessage<QSBGhostController, (Vector3 localPosition, float speed, float acceleration)>
 {
 	public MoveToLocalPositionMessage(Vector3 localPos, float speed, float accel) : base((localPos, speed, accel)) { }
 

--- a/QSB/EchoesOfTheEye/Ghosts/Messages/PathfindLocalPositionMessage.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Messages/PathfindLocalPositionMessage.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace QSB.EchoesOfTheEye.Ghosts.Messages;
 
-internal class PathfindLocalPositionMessage : QSBWorldObjectMessage<QSBGhostController,
+public class PathfindLocalPositionMessage : QSBWorldObjectMessage<QSBGhostController,
 	(Vector3 localPosition, float speed, float acceleration)>
 {
 	public PathfindLocalPositionMessage(Vector3 localPosition, float speed, float acceleration) :

--- a/QSB/EchoesOfTheEye/Ghosts/Messages/PathfindNodeMessage.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Messages/PathfindNodeMessage.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace QSB.EchoesOfTheEye.Ghosts.Messages;
 
-internal class PathfindNodeMessage : QSBWorldObjectMessage<QSBGhostController, (int mapId, int nodeIndex, float speed, float acceleration)>
+public class PathfindNodeMessage : QSBWorldObjectMessage<QSBGhostController, (int mapId, int nodeIndex, float speed, float acceleration)>
 {
 	public PathfindNodeMessage(GhostNode node, float speed, float acceleration) : base(Process(node, speed, acceleration)) { }
 

--- a/QSB/EchoesOfTheEye/Ghosts/Messages/PlayVoiceAudioMessage.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Messages/PlayVoiceAudioMessage.cs
@@ -3,7 +3,7 @@ using QSB.Messaging;
 
 namespace QSB.EchoesOfTheEye.Ghosts.Messages;
 
-internal class PlayVoiceAudioMessage : QSBWorldObjectMessage<QSBGhostEffects, (AudioType audioType, float volumeScale, bool near)>
+public class PlayVoiceAudioMessage : QSBWorldObjectMessage<QSBGhostEffects, (AudioType audioType, float volumeScale, bool near)>
 {
 	public PlayVoiceAudioMessage(AudioType audioType, float volumeScale, bool near) : base((audioType, volumeScale, near)) { }
 

--- a/QSB/EchoesOfTheEye/Ghosts/Messages/SetMovementStyleMessage.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Messages/SetMovementStyleMessage.cs
@@ -3,7 +3,7 @@ using QSB.Messaging;
 
 namespace QSB.EchoesOfTheEye.Ghosts.Messages;
 
-internal class SetMovementStyleMessage : QSBWorldObjectMessage<QSBGhostEffects, GhostEffects.MovementStyle>
+public class SetMovementStyleMessage : QSBWorldObjectMessage<QSBGhostEffects, GhostEffects.MovementStyle>
 {
 	public SetMovementStyleMessage(GhostEffects.MovementStyle style) : base(style) { }
 

--- a/QSB/EchoesOfTheEye/Ghosts/Messages/SpinMessage.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Messages/SpinMessage.cs
@@ -4,7 +4,7 @@ using QSB.Messaging;
 
 namespace QSB.EchoesOfTheEye.Ghosts.Messages;
 
-internal class SpinMessage : QSBWorldObjectMessage<QSBGhostController, TurnSpeed>
+public class SpinMessage : QSBWorldObjectMessage<QSBGhostController, TurnSpeed>
 {
 	public SpinMessage(TurnSpeed turnSpeed) : base(turnSpeed) { }
 

--- a/QSB/EchoesOfTheEye/Ghosts/Messages/StopFacingMessage.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Messages/StopFacingMessage.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace QSB.EchoesOfTheEye.Ghosts.Messages;
 
-internal class StopFacingMessage : QSBWorldObjectMessage<QSBGhostController>
+public class StopFacingMessage : QSBWorldObjectMessage<QSBGhostController>
 {
 	public override void OnReceiveRemote()
 	{

--- a/QSB/EchoesOfTheEye/Ghosts/Messages/StopMovingMessage.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Messages/StopMovingMessage.cs
@@ -10,7 +10,7 @@ using UnityEngine;
 
 namespace QSB.EchoesOfTheEye.Ghosts.Messages;
 
-internal class StopMovingMessage : QSBWorldObjectMessage<QSBGhostController, bool>
+public class StopMovingMessage : QSBWorldObjectMessage<QSBGhostController, bool>
 {
 	public StopMovingMessage(bool instant) : base(instant) { }
 

--- a/QSB/EchoesOfTheEye/Ghosts/Messages/Zone2ElevatorStateMessage.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Messages/Zone2ElevatorStateMessage.cs
@@ -4,7 +4,7 @@ using QSB.WorldSync;
 
 namespace QSB.EchoesOfTheEye.Ghosts.Messages;
 
-internal class Zone2ElevatorStateMessage : QSBMessage<(int index, Zone2ElevatorState state)>
+public class Zone2ElevatorStateMessage : QSBMessage<(int index, Zone2ElevatorState state)>
 {
 	public Zone2ElevatorStateMessage(int index, Zone2ElevatorState state) : base((index, state)) { }
 

--- a/QSB/EchoesOfTheEye/Ghosts/Patches/GhostBrainPatches.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Patches/GhostBrainPatches.cs
@@ -14,7 +14,7 @@ using UnityEngine;
 namespace QSB.EchoesOfTheEye.Ghosts.Patches;
 
 [HarmonyPatch(typeof(GhostBrain))]
-internal class GhostBrainPatches : QSBPatch
+public class GhostBrainPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/EchoesOfTheEye/Ghosts/Patches/GhostControllerPatches.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Patches/GhostControllerPatches.cs
@@ -16,7 +16,7 @@ using System.Threading.Tasks;
 namespace QSB.EchoesOfTheEye.Ghosts.Patches;
 
 [HarmonyPatch(typeof(GhostController))]
-internal class GhostControllerPatches : QSBPatch
+public class GhostControllerPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/EchoesOfTheEye/Ghosts/Patches/GhostEffectsPatches.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Patches/GhostEffectsPatches.cs
@@ -15,7 +15,7 @@ using UnityEngine;
 namespace QSB.EchoesOfTheEye.Ghosts.Patches;
 
 [HarmonyPatch(typeof(GhostEffects))]
-internal class GhostEffectsPatches : QSBPatch
+public class GhostEffectsPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/EchoesOfTheEye/Ghosts/Patches/GhostHotelDirectorPatches.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Patches/GhostHotelDirectorPatches.cs
@@ -7,7 +7,7 @@ using QSB.WorldSync;
 namespace QSB.EchoesOfTheEye.Ghosts.Patches;
 
 [HarmonyPatch(typeof(GhostHotelDirector))]
-internal class GhostHotelDirectorPatches : QSBPatch
+public class GhostHotelDirectorPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/EchoesOfTheEye/Ghosts/Patches/GhostPartyDirectorPatches.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Patches/GhostPartyDirectorPatches.cs
@@ -13,7 +13,7 @@ using UnityEngine;
 namespace QSB.EchoesOfTheEye.Ghosts.Patches;
 
 [HarmonyPatch(typeof(GhostPartyDirector))]
-internal class GhostPartyDirectorPatches : QSBPatch
+public class GhostPartyDirectorPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/EchoesOfTheEye/Ghosts/Patches/GhostPartyPathDirectorPatches.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Patches/GhostPartyPathDirectorPatches.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 namespace QSB.EchoesOfTheEye.Ghosts.Patches;
 
 [HarmonyPatch(typeof(GhostPartyPathDirector))]
-internal class GhostPartyPathDirectorPatches : QSBPatch
+public class GhostPartyPathDirectorPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/EchoesOfTheEye/Ghosts/Patches/GhostSensorsPatches.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Patches/GhostSensorsPatches.cs
@@ -14,7 +14,7 @@ using UnityEngine;
 namespace QSB.EchoesOfTheEye.Ghosts.Patches;
 
 [HarmonyPatch(typeof(GhostSensors))]
-internal class GhostSensorsPatches : QSBPatch
+public class GhostSensorsPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/EchoesOfTheEye/Ghosts/Patches/GhostZone2DirectorPatches.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/Patches/GhostZone2DirectorPatches.cs
@@ -11,7 +11,7 @@ using UnityEngine;
 
 namespace QSB.EchoesOfTheEye.Ghosts.Patches;
 
-internal class GhostZone2DirectorPatches : QSBPatch
+public class GhostZone2DirectorPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/EchoesOfTheEye/Ghosts/WorldObjects/QSBGhostNodeMap.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/WorldObjects/QSBGhostNodeMap.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace QSB.EchoesOfTheEye.Ghosts.WorldObjects;
 
-internal class QSBGhostNodeMap : WorldObject<GhostNodeMap>
+public class QSBGhostNodeMap : WorldObject<GhostNodeMap>
 {
 	public override void SendInitialState(uint to)
 	{

--- a/QSB/EchoesOfTheEye/Ghosts/WorldObjects/QSBPrisonerEffects.cs
+++ b/QSB/EchoesOfTheEye/Ghosts/WorldObjects/QSBPrisonerEffects.cs
@@ -2,7 +2,7 @@
 
 namespace QSB.EchoesOfTheEye.Ghosts.WorldObjects;
 
-internal class QSBPrisonerEffects : QSBGhostEffects
+public class QSBPrisonerEffects : QSBGhostEffects
 {
 	public override void PlaySleepAnimation(bool remote = false)
 	{

--- a/QSB/EchoesOfTheEye/LightSensorSync/LightSensorManager.cs
+++ b/QSB/EchoesOfTheEye/LightSensorSync/LightSensorManager.cs
@@ -7,7 +7,7 @@ using System.Threading;
 
 namespace QSB.EchoesOfTheEye.LightSensorSync;
 
-internal class LightSensorManager : WorldObjectManager
+public class LightSensorManager : WorldObjectManager
 {
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.Both;
 	public override bool DlcOnly => true;

--- a/QSB/EchoesOfTheEye/LightSensorSync/Messages/IlluminatingLanternsMessage.cs
+++ b/QSB/EchoesOfTheEye/LightSensorSync/Messages/IlluminatingLanternsMessage.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace QSB.EchoesOfTheEye.LightSensorSync.Messages;
 
-internal class IlluminatingLanternsMessage : QSBWorldObjectMessage<QSBLightSensor, int[]>
+public class IlluminatingLanternsMessage : QSBWorldObjectMessage<QSBLightSensor, int[]>
 {
 	public IlluminatingLanternsMessage(IEnumerable<DreamLanternController> lanterns) :
 		base(lanterns.Select(x => x.GetWorldObject<QSBDreamLanternController>().ObjectId).ToArray()) { }

--- a/QSB/EchoesOfTheEye/LightSensorSync/Messages/PlayerIlluminatingLanternsMessage.cs
+++ b/QSB/EchoesOfTheEye/LightSensorSync/Messages/PlayerIlluminatingLanternsMessage.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace QSB.EchoesOfTheEye.LightSensorSync.Messages;
 
-internal class PlayerIlluminatingLanternsMessage : QSBMessage<(uint playerId, int[] lanterns)>
+public class PlayerIlluminatingLanternsMessage : QSBMessage<(uint playerId, int[] lanterns)>
 {
 	public PlayerIlluminatingLanternsMessage(uint playerId, IEnumerable<DreamLanternController> lanterns) :
 		base((

--- a/QSB/EchoesOfTheEye/LightSensorSync/Messages/PlayerSetIlluminatedMessage.cs
+++ b/QSB/EchoesOfTheEye/LightSensorSync/Messages/PlayerSetIlluminatedMessage.cs
@@ -3,7 +3,7 @@ using QSB.Player;
 
 namespace QSB.EchoesOfTheEye.LightSensorSync.Messages;
 
-internal class PlayerSetIlluminatedMessage : QSBMessage<(uint playerId, bool illuminated)>
+public class PlayerSetIlluminatedMessage : QSBMessage<(uint playerId, bool illuminated)>
 {
 	public PlayerSetIlluminatedMessage(uint playerId, bool illuminated) : base((playerId, illuminated)) { }
 

--- a/QSB/EchoesOfTheEye/LightSensorSync/Messages/SetIlluminatedMessage.cs
+++ b/QSB/EchoesOfTheEye/LightSensorSync/Messages/SetIlluminatedMessage.cs
@@ -3,7 +3,7 @@ using QSB.Messaging;
 
 namespace QSB.EchoesOfTheEye.LightSensorSync.Messages;
 
-internal class SetIlluminatedMessage : QSBWorldObjectMessage<QSBLightSensor, bool>
+public class SetIlluminatedMessage : QSBWorldObjectMessage<QSBLightSensor, bool>
 {
 	public SetIlluminatedMessage(bool illuminated) : base(illuminated) { }
 

--- a/QSB/EchoesOfTheEye/LightSensorSync/Patches/LightSensorPatches.cs
+++ b/QSB/EchoesOfTheEye/LightSensorSync/Patches/LightSensorPatches.cs
@@ -21,7 +21,7 @@ using UnityEngine;
 namespace QSB.EchoesOfTheEye.LightSensorSync.Patches;
 
 [HarmonyPatch(typeof(SingleLightSensor))]
-internal class LightSensorPatches : QSBPatch
+public class LightSensorPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/EchoesOfTheEye/LightSensorSync/WorldObjects/QSBLightSensor.cs
+++ b/QSB/EchoesOfTheEye/LightSensorSync/WorldObjects/QSBLightSensor.cs
@@ -14,7 +14,7 @@ using System.Threading;
 
 namespace QSB.EchoesOfTheEye.LightSensorSync.WorldObjects;
 
-internal class QSBLightSensor : OwnedWorldObject<SingleLightSensor>
+public class QSBLightSensor : OwnedWorldObject<SingleLightSensor>
 {
 	internal bool _locallyIlluminated;
 

--- a/QSB/EchoesOfTheEye/PictureFrameDoors/Messages/PictureFrameDoorMessage.cs
+++ b/QSB/EchoesOfTheEye/PictureFrameDoors/Messages/PictureFrameDoorMessage.cs
@@ -3,7 +3,7 @@ using QSB.Messaging;
 
 namespace QSB.EchoesOfTheEye.PictureFrameDoors.Messages;
 
-internal class PictureFrameDoorMessage : QSBWorldObjectMessage<IQSBPictureFrameDoor, bool>
+public class PictureFrameDoorMessage : QSBWorldObjectMessage<IQSBPictureFrameDoor, bool>
 {
 	public PictureFrameDoorMessage(bool open) : base(open) { }
 

--- a/QSB/EchoesOfTheEye/PictureFrameDoors/Patches/PictureFrameDoorInterfacePatches.cs
+++ b/QSB/EchoesOfTheEye/PictureFrameDoors/Patches/PictureFrameDoorInterfacePatches.cs
@@ -7,7 +7,7 @@ using QSB.WorldSync;
 
 namespace QSB.EchoesOfTheEye.PictureFrameDoors.Patches;
 
-internal class PictureFrameDoorInterfacePatches : QSBPatch
+public class PictureFrameDoorInterfacePatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/EchoesOfTheEye/PictureFrameDoors/PictureFrameDoorsManager.cs
+++ b/QSB/EchoesOfTheEye/PictureFrameDoors/PictureFrameDoorsManager.cs
@@ -5,7 +5,7 @@ using System.Threading;
 
 namespace QSB.EchoesOfTheEye.PictureFrameDoors;
 
-internal class PictureFrameDoorsManager : WorldObjectManager
+public class PictureFrameDoorsManager : WorldObjectManager
 {
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.SolarSystem;
 	public override bool DlcOnly => true;

--- a/QSB/EchoesOfTheEye/PictureFrameDoors/WorldObjects/IQSBPictureFrameDoor.cs
+++ b/QSB/EchoesOfTheEye/PictureFrameDoors/WorldObjects/IQSBPictureFrameDoor.cs
@@ -2,7 +2,7 @@
 
 namespace QSB.EchoesOfTheEye.PictureFrameDoors.WorldObjects;
 
-internal interface IQSBPictureFrameDoor : IWorldObject
+public interface IQSBPictureFrameDoor : IWorldObject
 {
 	public void SetOpenState(bool open);
 }

--- a/QSB/EchoesOfTheEye/PictureFrameDoors/WorldObjects/QSBGlitchedCodeDoorInterface.cs
+++ b/QSB/EchoesOfTheEye/PictureFrameDoors/WorldObjects/QSBGlitchedCodeDoorInterface.cs
@@ -1,6 +1,6 @@
 ﻿namespace QSB.EchoesOfTheEye.PictureFrameDoors.WorldObjects;
 
-internal class QSBGlitchedCodeDoorInterface : QSBPictureFrameDoor<GlitchedCodeDoorInterface>
+public class QSBGlitchedCodeDoorInterface : QSBPictureFrameDoor<GlitchedCodeDoorInterface>
 {
 	public override void SetOpenState(bool open)
 	{

--- a/QSB/EchoesOfTheEye/PictureFrameDoors/WorldObjects/QSBPictureFrameDoorInterface.cs
+++ b/QSB/EchoesOfTheEye/PictureFrameDoors/WorldObjects/QSBPictureFrameDoorInterface.cs
@@ -1,6 +1,6 @@
 ﻿namespace QSB.EchoesOfTheEye.PictureFrameDoors.WorldObjects;
 
-internal class QSBPictureFrameDoorInterface : QSBPictureFrameDoor<PictureFrameDoorInterface>
+public class QSBPictureFrameDoorInterface : QSBPictureFrameDoor<PictureFrameDoorInterface>
 {
 	public override void SetOpenState(bool open)
 	{

--- a/QSB/EchoesOfTheEye/Prisoner/CustomAutoSlideProjector.cs
+++ b/QSB/EchoesOfTheEye/Prisoner/CustomAutoSlideProjector.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace QSB.EchoesOfTheEye.Prisoner;
 
-internal class CustomAutoSlideProjector : MonoBehaviour
+public class CustomAutoSlideProjector : MonoBehaviour
 {
 	public float _defaultSlideDuration;
 	public float _endPauseDuration;

--- a/QSB/EchoesOfTheEye/Prisoner/Messages/CellevatorCallMessage.cs
+++ b/QSB/EchoesOfTheEye/Prisoner/Messages/CellevatorCallMessage.cs
@@ -3,7 +3,7 @@ using QSB.Messaging;
 
 namespace QSB.EchoesOfTheEye.Prisoner.Messages;
 
-internal class CellevatorCallMessage : QSBWorldObjectMessage<QSBPrisonCellElevator, int>
+public class CellevatorCallMessage : QSBWorldObjectMessage<QSBPrisonCellElevator, int>
 {
 	public CellevatorCallMessage(int floorIndex) : base(floorIndex) { }
 	public override void OnReceiveRemote() => WorldObject.AttachedObject.CallElevatorToFloor(Data);

--- a/QSB/EchoesOfTheEye/Prisoner/Messages/EmergeTriggerMessage.cs
+++ b/QSB/EchoesOfTheEye/Prisoner/Messages/EmergeTriggerMessage.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace QSB.EchoesOfTheEye.Prisoner.Messages;
 
-internal class EmergeTriggerMessage : QSBMessage
+public class EmergeTriggerMessage : QSBMessage
 {
 	public override void OnReceiveRemote()
 	{

--- a/QSB/EchoesOfTheEye/Prisoner/Messages/EnterLightsOutMessage.cs
+++ b/QSB/EchoesOfTheEye/Prisoner/Messages/EnterLightsOutMessage.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace QSB.EchoesOfTheEye.Prisoner.Messages;
 
-internal class EnterLightsOutMessage : QSBMessage
+public class EnterLightsOutMessage : QSBMessage
 {
 	public override void OnReceiveRemote()
 	{

--- a/QSB/EchoesOfTheEye/Prisoner/Messages/MindProjectionCompleteMessage.cs
+++ b/QSB/EchoesOfTheEye/Prisoner/Messages/MindProjectionCompleteMessage.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace QSB.EchoesOfTheEye.Prisoner.Messages;
 
-internal class MindProjectionCompleteMessage : QSBMessage
+public class MindProjectionCompleteMessage : QSBMessage
 {
 	public override void OnReceiveRemote()
 	{

--- a/QSB/EchoesOfTheEye/Prisoner/Messages/PrisonerEnterBehaviourMessage.cs
+++ b/QSB/EchoesOfTheEye/Prisoner/Messages/PrisonerEnterBehaviourMessage.cs
@@ -4,7 +4,7 @@ using QSB.WorldSync;
 
 namespace QSB.EchoesOfTheEye.Prisoner.Messages;
 
-internal class PrisonerEnterBehaviourMessage : QSBWorldObjectMessage<QSBPrisonerBrain, (PrisonerBehavior behaviour, int markerIndex)>
+public class PrisonerEnterBehaviourMessage : QSBWorldObjectMessage<QSBPrisonerBrain, (PrisonerBehavior behaviour, int markerIndex)>
 {
 	public PrisonerEnterBehaviourMessage(PrisonerBehavior behaviour, PrisonerBehaviourCueMarker marker)
 		: base((behaviour, marker != null ? marker.GetWorldObject<QSBPrisonerMarker>().ObjectId : -1)) { }

--- a/QSB/EchoesOfTheEye/Prisoner/Messages/ProjectMessage.cs
+++ b/QSB/EchoesOfTheEye/Prisoner/Messages/ProjectMessage.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace QSB.EchoesOfTheEye.Prisoner.Messages;
 
-internal class ProjectMessage : QSBMessage
+public class ProjectMessage : QSBMessage
 {
 	public override void OnReceiveRemote()
 	{

--- a/QSB/EchoesOfTheEye/Prisoner/Messages/StopProjectMessage.cs
+++ b/QSB/EchoesOfTheEye/Prisoner/Messages/StopProjectMessage.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace QSB.EchoesOfTheEye.Prisoner.Messages;
 
-internal class StopProjectMessage : QSBMessage<bool>
+public class StopProjectMessage : QSBMessage<bool>
 {
 	public StopProjectMessage(bool done) : base(done) { }
 

--- a/QSB/EchoesOfTheEye/Prisoner/Patches/PrisonerBrainPatches.cs
+++ b/QSB/EchoesOfTheEye/Prisoner/Patches/PrisonerBrainPatches.cs
@@ -11,7 +11,7 @@ using UnityEngine;
 namespace QSB.EchoesOfTheEye.Prisoner.Patches;
 
 [HarmonyPatch(typeof(PrisonerBrain))]
-internal class PrisonerBrainPatches : QSBPatch
+public class PrisonerBrainPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/EchoesOfTheEye/Prisoner/PrisonerBehaviourCueMarker.cs
+++ b/QSB/EchoesOfTheEye/Prisoner/PrisonerBehaviourCueMarker.cs
@@ -2,4 +2,4 @@
 
 namespace QSB.EchoesOfTheEye.Prisoner;
 
-internal class PrisonerBehaviourCueMarker : MonoBehaviour { }
+public class PrisonerBehaviourCueMarker : MonoBehaviour { }

--- a/QSB/EchoesOfTheEye/Prisoner/PrisonerManager.cs
+++ b/QSB/EchoesOfTheEye/Prisoner/PrisonerManager.cs
@@ -11,7 +11,7 @@ using UnityEngine;
 
 namespace QSB.EchoesOfTheEye.Prisoner;
 
-internal class PrisonerManager : WorldObjectManager
+public class PrisonerManager : WorldObjectManager
 {
 	public override bool DlcOnly => true;
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.SolarSystem;

--- a/QSB/EchoesOfTheEye/Prisoner/WorldObjects/QSBPrisonCellElevator.cs
+++ b/QSB/EchoesOfTheEye/Prisoner/WorldObjects/QSBPrisonCellElevator.cs
@@ -6,7 +6,7 @@ using QSB.WorldSync;
 
 namespace QSB.EchoesOfTheEye.Prisoner.WorldObjects;
 
-internal class QSBPrisonCellElevator : WorldObject<PrisonCellElevator>, IQSBDropTarget, IGhostObject
+public class QSBPrisonCellElevator : WorldObject<PrisonCellElevator>, IQSBDropTarget, IGhostObject
 {
 	public override void SendInitialState(uint to) =>
 		this.SendMessage(new CellevatorCallMessage(AttachedObject._targetFloorIndex) { To = to });

--- a/QSB/EchoesOfTheEye/Prisoner/WorldObjects/QSBPrisonerBrain.cs
+++ b/QSB/EchoesOfTheEye/Prisoner/WorldObjects/QSBPrisonerBrain.cs
@@ -10,7 +10,7 @@ using UnityEngine;
 
 namespace QSB.EchoesOfTheEye.Prisoner.WorldObjects;
 
-internal class QSBPrisonerBrain : WorldObject<PrisonerBrain>, IGhostObject
+public class QSBPrisonerBrain : WorldObject<PrisonerBrain>, IGhostObject
 {
 	public override void SendInitialState(uint to)
 	{

--- a/QSB/EchoesOfTheEye/Prisoner/WorldObjects/QSBPrisonerMarker.cs
+++ b/QSB/EchoesOfTheEye/Prisoner/WorldObjects/QSBPrisonerMarker.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace QSB.EchoesOfTheEye.Prisoner.WorldObjects;
 
-internal class QSBPrisonerMarker : WorldObject<PrisonerBehaviourCueMarker>
+public class QSBPrisonerMarker : WorldObject<PrisonerBehaviourCueMarker>
 {
 	public Transform Transform => AttachedObject.transform;
 }

--- a/QSB/EchoesOfTheEye/QSBRotatingElements.cs
+++ b/QSB/EchoesOfTheEye/QSBRotatingElements.cs
@@ -11,7 +11,7 @@ using UnityEngine;
 
 namespace QSB.EchoesOfTheEye;
 
-internal abstract class QSBRotatingElements<T, U> : LinkedWorldObject<T, U>
+public abstract class QSBRotatingElements<T, U> : LinkedWorldObject<T, U>
 	where T : MonoBehaviour
 	where U : NetworkBehaviour
 {

--- a/QSB/EchoesOfTheEye/RotatingElementsVariableSyncer.cs
+++ b/QSB/EchoesOfTheEye/RotatingElementsVariableSyncer.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace QSB.EchoesOfTheEye;
 
-internal abstract class RotatingElementsVariableSyncer<TWorldObject> : BaseVariableSyncer<Quaternion[]>, ILinkedNetworkBehaviour
+public abstract class RotatingElementsVariableSyncer<TWorldObject> : BaseVariableSyncer<Quaternion[]>, ILinkedNetworkBehaviour
 	where TWorldObject : IWorldObject
 {
 	public override void OnStartClient()

--- a/QSB/EchoesOfTheEye/SlideProjectors/Messages/NextSlideMessage.cs
+++ b/QSB/EchoesOfTheEye/SlideProjectors/Messages/NextSlideMessage.cs
@@ -3,7 +3,7 @@ using QSB.Messaging;
 
 namespace QSB.EchoesOfTheEye.SlideProjectors.Messages;
 
-internal class NextSlideMessage : QSBWorldObjectMessage<QSBSlideProjector>
+public class NextSlideMessage : QSBWorldObjectMessage<QSBSlideProjector>
 {
 	public override void OnReceiveRemote() => WorldObject.AttachedObject.NextSlide();
 }

--- a/QSB/EchoesOfTheEye/SlideProjectors/Messages/PreviousSlideMessage.cs
+++ b/QSB/EchoesOfTheEye/SlideProjectors/Messages/PreviousSlideMessage.cs
@@ -3,7 +3,7 @@ using QSB.Messaging;
 
 namespace QSB.EchoesOfTheEye.SlideProjectors.Messages;
 
-internal class PreviousSlideMessage : QSBWorldObjectMessage<QSBSlideProjector>
+public class PreviousSlideMessage : QSBWorldObjectMessage<QSBSlideProjector>
 {
 	public override void OnReceiveRemote() => WorldObject.AttachedObject.PreviousSlide();
 }

--- a/QSB/EchoesOfTheEye/SlideProjectors/Patches/SlideProjectorPatches.cs
+++ b/QSB/EchoesOfTheEye/SlideProjectors/Patches/SlideProjectorPatches.cs
@@ -8,7 +8,7 @@ using QSB.WorldSync;
 namespace QSB.EchoesOfTheEye.SlideProjectors.Patches;
 
 [HarmonyPatch(typeof(SlideProjector))]
-internal class SlideProjectorPatches : QSBPatch
+public class SlideProjectorPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/EchoesOfTheEye/SlideProjectors/SlideProjectorManager.cs
+++ b/QSB/EchoesOfTheEye/SlideProjectors/SlideProjectorManager.cs
@@ -5,7 +5,7 @@ using System.Threading;
 
 namespace QSB.EchoesOfTheEye.SlideProjectors;
 
-internal class SlideProjectorManager : WorldObjectManager
+public class SlideProjectorManager : WorldObjectManager
 {
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.SolarSystem;
 	public override bool DlcOnly => true;

--- a/QSB/EchoesOfTheEye/WineCellar/Messages/WineCellarSwitchMessage.cs
+++ b/QSB/EchoesOfTheEye/WineCellar/Messages/WineCellarSwitchMessage.cs
@@ -3,7 +3,7 @@ using QSB.Messaging;
 
 namespace QSB.EchoesOfTheEye.WineCellar.Messages;
 
-internal class WineCellarSwitchMessage : QSBWorldObjectMessage<QSBWineCellarSwitch>
+public class WineCellarSwitchMessage : QSBWorldObjectMessage<QSBWineCellarSwitch>
 {
 	public override void OnReceiveRemote() => WorldObject.AttachedObject.OnPressInteract();
 }

--- a/QSB/EchoesOfTheEye/WineCellar/Patches/WineCellarPatches.cs
+++ b/QSB/EchoesOfTheEye/WineCellar/Patches/WineCellarPatches.cs
@@ -7,7 +7,7 @@ using QSB.WorldSync;
 
 namespace QSB.EchoesOfTheEye.WineCellar.Patches;
 
-internal class WineCellarPatches : QSBPatch
+public class WineCellarPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/EchoesOfTheEye/WineCellar/WineCellarManager.cs
+++ b/QSB/EchoesOfTheEye/WineCellar/WineCellarManager.cs
@@ -5,7 +5,7 @@ using System.Threading;
 
 namespace QSB.EchoesOfTheEye.WineCellar;
 
-internal class WineCellarManager : WorldObjectManager
+public class WineCellarManager : WorldObjectManager
 {
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.SolarSystem;
 	public override bool DlcOnly => true;

--- a/QSB/EchoesOfTheEye/WineCellar/WorldObjects/QSBWineCellarSwitch.cs
+++ b/QSB/EchoesOfTheEye/WineCellar/WorldObjects/QSBWineCellarSwitch.cs
@@ -4,7 +4,7 @@ using QSB.WorldSync;
 
 namespace QSB.EchoesOfTheEye.WineCellar.WorldObjects;
 
-internal class QSBWineCellarSwitch : WorldObject<WineCellarSwitch>
+public class QSBWineCellarSwitch : WorldObject<WineCellarSwitch>
 {
 	public override void SendInitialState(uint to)
 	{

--- a/QSB/EyeOfTheUniverse/EyeStateSync/Messages/EyeStateMessage.cs
+++ b/QSB/EyeOfTheUniverse/EyeStateSync/Messages/EyeStateMessage.cs
@@ -8,7 +8,7 @@ namespace QSB.EyeOfTheUniverse.EyeStateSync.Messages;
 /// <summary>
 /// todo SendInitialState
 /// </summary>
-internal class EyeStateMessage : QSBMessage<EyeState>
+public class EyeStateMessage : QSBMessage<EyeState>
 {
 	static EyeStateMessage() => GlobalMessenger<EyeState>.AddListener(OWEvents.EyeStateChanged, Handler);
 

--- a/QSB/EyeOfTheUniverse/EyeStateSync/Messages/FlickerMessage.cs
+++ b/QSB/EyeOfTheUniverse/EyeStateSync/Messages/FlickerMessage.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 
 namespace QSB.EyeOfTheUniverse.EyeStateSync.Messages;
 
-internal class FlickerMessage : QSBMessage
+public class FlickerMessage : QSBMessage
 {
 	public static bool IgnoreNextMessage;
 

--- a/QSB/EyeOfTheUniverse/ForestOfGalaxies/Messages/EyeCloneSeenMessage.cs
+++ b/QSB/EyeOfTheUniverse/ForestOfGalaxies/Messages/EyeCloneSeenMessage.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace QSB.EyeOfTheUniverse.ForestOfGalaxies.Messages;
 
-internal class EyeCloneSeenMessage : QSBMessage
+public class EyeCloneSeenMessage : QSBMessage
 {
 
 	public override bool ShouldReceive => QSBWorldSync.AllObjectsReady;

--- a/QSB/EyeOfTheUniverse/ForestOfGalaxies/Messages/KillGalaxiesMessage.cs
+++ b/QSB/EyeOfTheUniverse/ForestOfGalaxies/Messages/KillGalaxiesMessage.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 
 namespace QSB.EyeOfTheUniverse.ForestOfGalaxies.Messages;
 
-internal class KillGalaxiesMessage : QSBMessage
+public class KillGalaxiesMessage : QSBMessage
 {
 	private List<float> _deathDelays;
 

--- a/QSB/EyeOfTheUniverse/ForestOfGalaxies/Patches/ForestPatches.cs
+++ b/QSB/EyeOfTheUniverse/ForestOfGalaxies/Patches/ForestPatches.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace QSB.EyeOfTheUniverse.ForestOfGalaxies.Patches;
 
-internal class ForestPatches : QSBPatch
+public class ForestPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/EyeOfTheUniverse/GalaxyMap/CustomDialogueTree.cs
+++ b/QSB/EyeOfTheUniverse/GalaxyMap/CustomDialogueTree.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace QSB.EyeOfTheUniverse.GalaxyMap;
 
-internal class CustomDialogueTree : MonoBehaviour
+public class CustomDialogueTree : MonoBehaviour
 {
 	public TextAsset _xmlCharacterDialogueAsset;
 	public Transform _attentionPoint;

--- a/QSB/EyeOfTheUniverse/GalaxyMap/GalaxyMapManager.cs
+++ b/QSB/EyeOfTheUniverse/GalaxyMap/GalaxyMapManager.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace QSB.EyeOfTheUniverse.GalaxyMap;
 
-internal class GalaxyMapManager : MonoBehaviour, IAddComponentOnStart
+public class GalaxyMapManager : MonoBehaviour, IAddComponentOnStart
 {
 	public static GalaxyMapManager Instance { get; private set; }
 

--- a/QSB/EyeOfTheUniverse/GalaxyMap/Messages/ZoomOutMessage.cs
+++ b/QSB/EyeOfTheUniverse/GalaxyMap/Messages/ZoomOutMessage.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace QSB.EyeOfTheUniverse.GalaxyMap.Messages;
 
-internal class ZoomOutMessage : QSBMessage
+public class ZoomOutMessage : QSBMessage
 {
 	public override bool ShouldReceive => QSBWorldSync.AllObjectsReady;
 

--- a/QSB/EyeOfTheUniverse/GalaxyMap/Patches/GalaxyMapPatches.cs
+++ b/QSB/EyeOfTheUniverse/GalaxyMap/Patches/GalaxyMapPatches.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace QSB.EyeOfTheUniverse.GalaxyMap.Patches;
 
-internal class GalaxyMapPatches : QSBPatch
+public class GalaxyMapPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/EyeOfTheUniverse/GalaxyMap/QSBDialogueNode.cs
+++ b/QSB/EyeOfTheUniverse/GalaxyMap/QSBDialogueNode.cs
@@ -2,7 +2,7 @@
 
 namespace QSB.EyeOfTheUniverse.GalaxyMap;
 
-internal class QSBDialogueNode
+public class QSBDialogueNode
 {
 	private List<string> _listPagesToDisplay;
 

--- a/QSB/EyeOfTheUniverse/InstrumentSync/Messages/GatherInstrumentMessage.cs
+++ b/QSB/EyeOfTheUniverse/InstrumentSync/Messages/GatherInstrumentMessage.cs
@@ -3,7 +3,7 @@ using QSB.Messaging;
 
 namespace QSB.EyeOfTheUniverse.InstrumentSync.Messages;
 
-internal class GatherInstrumentMessage : QSBWorldObjectMessage<QSBQuantumInstrument>
+public class GatherInstrumentMessage : QSBWorldObjectMessage<QSBQuantumInstrument>
 {
 	public override void OnReceiveRemote() => WorldObject.Gather();
 }

--- a/QSB/EyeOfTheUniverse/InstrumentSync/Patches/QuantumInstrumentPatches.cs
+++ b/QSB/EyeOfTheUniverse/InstrumentSync/Patches/QuantumInstrumentPatches.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace QSB.EyeOfTheUniverse.InstrumentSync.Patches;
 
-internal class QuantumInstrumentPatches : QSBPatch
+public class QuantumInstrumentPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/EyeOfTheUniverse/InstrumentSync/QuantumInstrumentManager.cs
+++ b/QSB/EyeOfTheUniverse/InstrumentSync/QuantumInstrumentManager.cs
@@ -5,7 +5,7 @@ using System.Threading;
 
 namespace QSB.EyeOfTheUniverse.InstrumentSync;
 
-internal class QuantumInstrumentManager : WorldObjectManager
+public class QuantumInstrumentManager : WorldObjectManager
 {
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.Eye;
 

--- a/QSB/EyeOfTheUniverse/InstrumentSync/WorldObjects/QSBQuantumInstrument.cs
+++ b/QSB/EyeOfTheUniverse/InstrumentSync/WorldObjects/QSBQuantumInstrument.cs
@@ -3,7 +3,7 @@ using QSB.WorldSync;
 
 namespace QSB.EyeOfTheUniverse.InstrumentSync.WorldObjects;
 
-internal class QSBQuantumInstrument : WorldObject<QuantumInstrument>
+public class QSBQuantumInstrument : WorldObject<QuantumInstrument>
 {
 	public void Gather()
 	{

--- a/QSB/EyeOfTheUniverse/MaskSync/MaskManager.cs
+++ b/QSB/EyeOfTheUniverse/MaskSync/MaskManager.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace QSB.EyeOfTheUniverse.MaskSync;
 
-internal class MaskManager : MonoBehaviour, IAddComponentOnStart
+public class MaskManager : MonoBehaviour, IAddComponentOnStart
 {
 	private static bool _flickering;
 	private static float _flickerOutTime;

--- a/QSB/EyeOfTheUniverse/MaskSync/Patches/MaskPatches.cs
+++ b/QSB/EyeOfTheUniverse/MaskSync/Patches/MaskPatches.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 
 namespace QSB.EyeOfTheUniverse.MaskSync.Patches;
 
-internal class MaskPatches : QSBPatch
+public class MaskPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/EyeOfTheUniverse/Tomb/EyeTombWatcher.cs
+++ b/QSB/EyeOfTheUniverse/Tomb/EyeTombWatcher.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace QSB.EyeOfTheUniverse.Tomb;
 
-internal class EyeTombWatcher : MonoBehaviour
+public class EyeTombWatcher : MonoBehaviour
 {
 	private EyeTombController _tomb;
 

--- a/QSB/EyeOfTheUniverse/Tomb/Messages/CloseDoorMessage.cs
+++ b/QSB/EyeOfTheUniverse/Tomb/Messages/CloseDoorMessage.cs
@@ -4,7 +4,7 @@ using QSB.WorldSync;
 
 namespace QSB.EyeOfTheUniverse.Tomb.Messages;
 
-internal class CloseDoorMessage : QSBMessage
+public class CloseDoorMessage : QSBMessage
 {
 	public override void OnReceiveRemote()
 	{

--- a/QSB/EyeOfTheUniverse/Tomb/Messages/EnterExitStageMessage.cs
+++ b/QSB/EyeOfTheUniverse/Tomb/Messages/EnterExitStageMessage.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace QSB.EyeOfTheUniverse.Tomb.Messages;
 
-internal class EnterExitStageMessage : QSBMessage<bool>
+public class EnterExitStageMessage : QSBMessage<bool>
 {
 	public EnterExitStageMessage(bool enter) : base(enter) { }
 

--- a/QSB/EyeOfTheUniverse/Tomb/Messages/ShowStageMessage.cs
+++ b/QSB/EyeOfTheUniverse/Tomb/Messages/ShowStageMessage.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace QSB.EyeOfTheUniverse.Tomb.Messages;
 
-internal class ShowStageMessage : QSBMessage
+public class ShowStageMessage : QSBMessage
 {
 	public override void OnReceiveRemote()
 	{

--- a/QSB/EyeOfTheUniverse/Tomb/Messages/ToggleLitStateMessage.cs
+++ b/QSB/EyeOfTheUniverse/Tomb/Messages/ToggleLitStateMessage.cs
@@ -4,7 +4,7 @@ using QSB.WorldSync;
 
 namespace QSB.EyeOfTheUniverse.Tomb.Messages;
 
-internal class ToggleLitStateMessage : QSBMessage<(int stateIndex, int direction, bool wasLit)>
+public class ToggleLitStateMessage : QSBMessage<(int stateIndex, int direction, bool wasLit)>
 {
 	public ToggleLitStateMessage(int currentStateIndex, int direction, bool wasLit) : base((currentStateIndex, direction, wasLit)) { }
 

--- a/QSB/EyeOfTheUniverse/Tomb/Messages/UseTombMessage.cs
+++ b/QSB/EyeOfTheUniverse/Tomb/Messages/UseTombMessage.cs
@@ -3,7 +3,7 @@ using QSB.WorldSync;
 
 namespace QSB.EyeOfTheUniverse.Tomb.Messages;
 
-internal class UseTombMessage : QSBMessage<bool>
+public class UseTombMessage : QSBMessage<bool>
 {
 	public UseTombMessage(bool use) : base(use) { }
 

--- a/QSB/EyeOfTheUniverse/Tomb/Patches/EyeMirrorControllerPatches.cs
+++ b/QSB/EyeOfTheUniverse/Tomb/Patches/EyeMirrorControllerPatches.cs
@@ -14,7 +14,7 @@ using UnityEngine;
 namespace QSB.EyeOfTheUniverse.Tomb.Patches;
 
 [HarmonyPatch(typeof(EyeMirrorController))]
-internal class EyeMirrorControllerPatches : QSBPatch
+public class EyeMirrorControllerPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/EyeOfTheUniverse/Tomb/Patches/EyeTombControllerPatches.cs
+++ b/QSB/EyeOfTheUniverse/Tomb/Patches/EyeTombControllerPatches.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 namespace QSB.EyeOfTheUniverse.Tomb.Patches;
 
 [HarmonyPatch(typeof(EyeTombController))]
-internal class EyeTombControllerPatches : QSBPatch
+public class EyeTombControllerPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/EyeOfTheUniverse/Tomb/TombManager.cs
+++ b/QSB/EyeOfTheUniverse/Tomb/TombManager.cs
@@ -4,7 +4,7 @@ using System.Threading;
 
 namespace QSB.EyeOfTheUniverse.Tomb;
 
-internal class TombManager : WorldObjectManager
+public class TombManager : WorldObjectManager
 {
 	public override bool DlcOnly => true;
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.Eye;

--- a/QSB/GeyserSync/Patches/GeyserPatches.cs
+++ b/QSB/GeyserSync/Patches/GeyserPatches.cs
@@ -4,7 +4,7 @@ using QSB.Patches;
 namespace QSB.GeyserSync.Patches;
 
 [HarmonyPatch]
-internal class GeyserPatches : QSBPatch
+public class GeyserPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnNonServerClientConnect;
 

--- a/QSB/Ghostbuster.cs
+++ b/QSB/Ghostbuster.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using UnityEngine;
 
 namespace QSB;
-internal class Ghostbuster : MonoBehaviour, IAddComponentOnStart
+public class Ghostbuster : MonoBehaviour, IAddComponentOnStart
 {
 	private const int UpdateInterval = 60;
 

--- a/QSB/HUD/Messages/ChatMessage.cs
+++ b/QSB/HUD/Messages/ChatMessage.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace QSB.HUD.Messages;
 
-internal class ChatMessage : QSBMessage<(string message, Color color)>
+public class ChatMessage : QSBMessage<(string message, Color color)>
 {
 	public ChatMessage(string msg, Color color) : base((msg, color)) { }
 

--- a/QSB/HUD/Messages/PlanetMessage.cs
+++ b/QSB/HUD/Messages/PlanetMessage.cs
@@ -4,7 +4,7 @@ using QSB.Utility;
 
 namespace QSB.HUD.Messages;
 
-internal class PlanetMessage : QSBMessage<HUDIcon>
+public class PlanetMessage : QSBMessage<HUDIcon>
 {
 	public PlanetMessage(HUDIcon icon) : base(icon) { }
 

--- a/QSB/HUD/MultiplayerHUDManager.cs
+++ b/QSB/HUD/MultiplayerHUDManager.cs
@@ -322,6 +322,7 @@ internal class MultiplayerHUDManager : MonoBehaviour, IAddComponentOnStart
 		var inputFieldGO = _textChat.Find("InputField");
 		_inputField = inputFieldGO.GetComponent<InputField>();
 		_inputField.text = "";
+		_inputField.characterLimit = 256;
 		_textChat.Find("Messages").Find("Message").GetComponent<Text>().text = "";
 		_lines.Clear();
 		_messages.Clear();

--- a/QSB/HUD/MultiplayerHUDManager.cs
+++ b/QSB/HUD/MultiplayerHUDManager.cs
@@ -83,6 +83,13 @@ internal class MultiplayerHUDManager : MonoBehaviour, IAddComponentOnStart
 	private readonly ListStack<(string msg, Color color)> _messages = new(false);
 	private float _lastMessageTime;
 
+	// this just exists so i can patch this in my tts addon
+	// perks of being a qsb dev :-)
+	public void WriteSystemMessage(string message, Color color)
+	{
+		WriteMessage(message, color);
+	}
+
 	public void WriteMessage(string message, Color color)
 	{
 		// dont write messages when not ready
@@ -453,7 +460,7 @@ internal class MultiplayerHUDManager : MonoBehaviour, IAddComponentOnStart
 		Destroy(player.HUDBox?.gameObject);
 		Destroy(player.MinimapPlayerMarker);
 
-		WriteMessage(string.Format(QSBLocalization.Current.PlayerLeftTheGame, player.Name), Color.yellow);
+		WriteSystemMessage(string.Format(QSBLocalization.Current.PlayerLeftTheGame, player.Name), Color.yellow);
 	}
 
 	private PlanetTrigger CreateTrigger(string parentPath, HUDIcon icon)

--- a/QSB/HUD/MultiplayerHUDManager.cs
+++ b/QSB/HUD/MultiplayerHUDManager.cs
@@ -15,7 +15,7 @@ using UnityEngine.UI;
 
 namespace QSB.HUD;
 
-internal class MultiplayerHUDManager : MonoBehaviour, IAddComponentOnStart
+public class MultiplayerHUDManager : MonoBehaviour, IAddComponentOnStart
 {
 	public static MultiplayerHUDManager Instance;
 

--- a/QSB/HUD/Patches/MinimapPatches.cs
+++ b/QSB/HUD/Patches/MinimapPatches.cs
@@ -4,7 +4,7 @@ using QSB.Patches;
 namespace QSB.HUD.Patches;
 
 [HarmonyPatch(typeof(Minimap))]
-internal class MinimapPatches : QSBPatch
+public class MinimapPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/HUD/Patches/RulesetVolumePatches.cs
+++ b/QSB/HUD/Patches/RulesetVolumePatches.cs
@@ -12,7 +12,7 @@ using UnityEngine;
 namespace QSB.HUD.Patches;
 
 [HarmonyPatch(typeof(RulesetVolume))]
-internal class RulesetVolumePatches : QSBPatch
+public class RulesetVolumePatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/Inputs/Patches/InputPatches.cs
+++ b/QSB/Inputs/Patches/InputPatches.cs
@@ -4,7 +4,7 @@ using QSB.Patches;
 namespace QSB.Inputs.Patches;
 
 [HarmonyPatch]
-internal class InputPatches : QSBPatch
+public class InputPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/ItemSync/ItemManager.cs
+++ b/QSB/ItemSync/ItemManager.cs
@@ -11,7 +11,7 @@ using UnityEngine;
 
 namespace QSB.ItemSync;
 
-internal class ItemManager : WorldObjectManager
+public class ItemManager : WorldObjectManager
 {
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.Both;
 

--- a/QSB/ItemSync/Messages/DropItemMessage.cs
+++ b/QSB/ItemSync/Messages/DropItemMessage.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace QSB.ItemSync.Messages;
 
-internal class DropItemMessage : QSBWorldObjectMessage<IQSBItem,
+public class DropItemMessage : QSBWorldObjectMessage<IQSBItem,
 	(Vector3 localPosition, Vector3 localNormal, int sectorId, int dropTargetId, int rigidBodyId)>
 {
 	public DropItemMessage(Vector3 worldPosition, Vector3 worldNormal, Transform parent, Sector sector, IItemDropTarget customDropTarget, OWRigidbody targetRigidbody)

--- a/QSB/ItemSync/Messages/MoveToCarryMessage.cs
+++ b/QSB/ItemSync/Messages/MoveToCarryMessage.cs
@@ -5,7 +5,7 @@ using QSB.Utility;
 
 namespace QSB.ItemSync.Messages;
 
-internal class MoveToCarryMessage : QSBWorldObjectMessage<IQSBItem, uint>
+public class MoveToCarryMessage : QSBWorldObjectMessage<IQSBItem, uint>
 {
 	public MoveToCarryMessage(uint playerHolding) : base(playerHolding) { }
 

--- a/QSB/ItemSync/Messages/SocketItemMessage.cs
+++ b/QSB/ItemSync/Messages/SocketItemMessage.cs
@@ -7,7 +7,7 @@ using QSB.WorldSync;
 
 namespace QSB.ItemSync.Messages;
 
-internal class SocketItemMessage : QSBWorldObjectMessage<IQSBItem, (SocketMessageType Type, int SocketId)>
+public class SocketItemMessage : QSBWorldObjectMessage<IQSBItem, (SocketMessageType Type, int SocketId)>
 {
 	public SocketItemMessage(SocketMessageType type, OWItemSocket socket) : base((
 		type,

--- a/QSB/ItemSync/Patches/ItemRemotePatches.cs
+++ b/QSB/ItemSync/Patches/ItemRemotePatches.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace QSB.ItemSync.Patches;
 
-internal class ItemRemotePatches : QSBPatch
+public class ItemRemotePatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/ItemSync/Patches/ItemToolPatches.cs
+++ b/QSB/ItemSync/Patches/ItemToolPatches.cs
@@ -10,7 +10,7 @@ using UnityEngine;
 namespace QSB.ItemSync.Patches;
 
 [HarmonyPatch(typeof(ItemTool))]
-internal class ItemToolPatches : QSBPatch
+public class ItemToolPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/ItemSync/WorldObjects/Items/QSBNomaiConversationStone.cs
+++ b/QSB/ItemSync/WorldObjects/Items/QSBNomaiConversationStone.cs
@@ -1,3 +1,3 @@
 ﻿namespace QSB.ItemSync.WorldObjects.Items;
 
-internal class QSBNomaiConversationStone : QSBItem<NomaiConversationStone> { }
+public class QSBNomaiConversationStone : QSBItem<NomaiConversationStone> { }

--- a/QSB/ItemSync/WorldObjects/Items/QSBScrollItem.cs
+++ b/QSB/ItemSync/WorldObjects/Items/QSBScrollItem.cs
@@ -1,3 +1,3 @@
 ﻿namespace QSB.ItemSync.WorldObjects.Items;
 
-internal class QSBScrollItem : QSBItem<ScrollItem> { }
+public class QSBScrollItem : QSBItem<ScrollItem> { }

--- a/QSB/ItemSync/WorldObjects/Items/QSBSharedStone.cs
+++ b/QSB/ItemSync/WorldObjects/Items/QSBSharedStone.cs
@@ -1,3 +1,3 @@
 ﻿namespace QSB.ItemSync.WorldObjects.Items;
 
-internal class QSBSharedStone : QSBItem<SharedStone> { }
+public class QSBSharedStone : QSBItem<SharedStone> { }

--- a/QSB/ItemSync/WorldObjects/Items/QSBSimpleLanternItem.cs
+++ b/QSB/ItemSync/WorldObjects/Items/QSBSimpleLanternItem.cs
@@ -1,3 +1,3 @@
 ﻿namespace QSB.ItemSync.WorldObjects.Items;
 
-internal class QSBSimpleLanternItem : QSBItem<SimpleLanternItem> { }
+public class QSBSimpleLanternItem : QSBItem<SimpleLanternItem> { }

--- a/QSB/ItemSync/WorldObjects/Items/QSBSlideReelItem.cs
+++ b/QSB/ItemSync/WorldObjects/Items/QSBSlideReelItem.cs
@@ -1,3 +1,3 @@
 ﻿namespace QSB.ItemSync.WorldObjects.Items;
 
-internal class QSBSlideReelItem : QSBItem<SlideReelItem> { }
+public class QSBSlideReelItem : QSBItem<SlideReelItem> { }

--- a/QSB/ItemSync/WorldObjects/Items/QSBWarpCoreItem.cs
+++ b/QSB/ItemSync/WorldObjects/Items/QSBWarpCoreItem.cs
@@ -1,6 +1,6 @@
 ﻿namespace QSB.ItemSync.WorldObjects.Items;
 
-internal class QSBWarpCoreItem : QSBItem<WarpCoreItem>
+public class QSBWarpCoreItem : QSBItem<WarpCoreItem>
 {
 	public bool IsVesselCoreType() => AttachedObject.IsVesselCoreType();
 }

--- a/QSB/ItemSync/WorldObjects/Sockets/QSBItemSocket.cs
+++ b/QSB/ItemSync/WorldObjects/Sockets/QSBItemSocket.cs
@@ -3,7 +3,7 @@ using QSB.WorldSync;
 
 namespace QSB.ItemSync.WorldObjects.Sockets;
 
-internal class QSBItemSocket : WorldObject<OWItemSocket>
+public class QSBItemSocket : WorldObject<OWItemSocket>
 {
 	public bool IsSocketOccupied() => AttachedObject.IsSocketOccupied();
 

--- a/QSB/Menus/MenuManager.cs
+++ b/QSB/Menus/MenuManager.cs
@@ -16,7 +16,7 @@ using UnityEngine.UI;
 
 namespace QSB.Menus;
 
-internal class MenuManager : MonoBehaviour, IAddComponentOnStart
+public class MenuManager : MonoBehaviour, IAddComponentOnStart
 {
 	public static MenuManager Instance;
 

--- a/QSB/Messaging/QSBMessage.cs
+++ b/QSB/Messaging/QSBMessage.cs
@@ -7,7 +7,7 @@ public abstract class QSBMessage
 	/// <summary>
 	/// set automatically by Send
 	/// </summary>
-	protected internal uint From;
+	public uint From;
 	/// <summary>
 	/// (default) uint.MaxValue = send to everyone <br/>
 	/// 0 = send to host

--- a/QSB/Messaging/QSBMessage.cs
+++ b/QSB/Messaging/QSBMessage.cs
@@ -45,7 +45,7 @@ public abstract class QSBMessage
 
 public abstract class QSBMessage<D> : QSBMessage
 {
-	protected D Data { get; private set; }
+	public D Data { get; private set; }
 	protected QSBMessage(D data) => Data = data;
 
 	public override void Serialize(NetworkWriter writer)

--- a/QSB/Messaging/QSBMessage.cs
+++ b/QSB/Messaging/QSBMessage.cs
@@ -7,6 +7,7 @@ public abstract class QSBMessage
 	/// <summary>
 	/// set automatically by Send
 	/// </summary>
+	// public so it can be accessed by a patch
 	public uint From;
 	/// <summary>
 	/// (default) uint.MaxValue = send to everyone <br/>

--- a/QSB/Messaging/QSBMessageManager.cs
+++ b/QSB/Messaging/QSBMessageManager.cs
@@ -142,7 +142,7 @@ internal struct Wrapper : NetworkMessage
 	public static implicit operator Wrapper(QSBMessage msg) => new() { Msg = msg };
 }
 
-internal static class ReaderWriterExtensions
+public static class ReaderWriterExtensions
 {
 	private static QSBMessage ReadQSBMessage(this NetworkReader reader)
 	{

--- a/QSB/ModelShip/Messages/CrashModelShipMessage.cs
+++ b/QSB/ModelShip/Messages/CrashModelShipMessage.cs
@@ -3,7 +3,7 @@ using QSB.WorldSync;
 
 namespace QSB.ModelShip.Messages;
 
-internal class CrashModelShipMessage : QSBMessage
+public class CrashModelShipMessage : QSBMessage
 {
 	public CrashModelShipMessage() { }
 

--- a/QSB/ModelShip/Messages/RespawnModelShipMessage.cs
+++ b/QSB/ModelShip/Messages/RespawnModelShipMessage.cs
@@ -3,7 +3,7 @@ using QSB.WorldSync;
 
 namespace QSB.ModelShip.Messages;
 
-internal class RespawnModelShipMessage : QSBMessage<bool>
+public class RespawnModelShipMessage : QSBMessage<bool>
 {
 	public RespawnModelShipMessage(bool playEffects) : base(playEffects) { }
 

--- a/QSB/ModelShip/Messages/UseFlightConsoleMessage.cs
+++ b/QSB/ModelShip/Messages/UseFlightConsoleMessage.cs
@@ -8,7 +8,7 @@ using QSB.WorldSync;
 
 namespace QSB.ModelShip.Messages;
 
-internal class UseFlightConsoleMessage : QSBMessage<bool>
+public class UseFlightConsoleMessage : QSBMessage<bool>
 {
 	static UseFlightConsoleMessage()
 	{

--- a/QSB/ModelShip/ModelShipManager.cs
+++ b/QSB/ModelShip/ModelShipManager.cs
@@ -8,7 +8,7 @@ using System.Threading;
 
 namespace QSB.ModelShip;
 
-internal class ModelShipManager : WorldObjectManager
+public class ModelShipManager : WorldObjectManager
 {
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.SolarSystem;
 	public override bool DlcOnly => false;

--- a/QSB/ModelShip/Patches/ModelShipThrusterAudioPatches.cs
+++ b/QSB/ModelShip/Patches/ModelShipThrusterAudioPatches.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace QSB.ModelShip.Patches;
 
-internal class ModelShipThrusterAudioPatches : QSBPatch
+public class ModelShipThrusterAudioPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/ModelShip/Patches/ModelShipThrusterPatches.cs
+++ b/QSB/ModelShip/Patches/ModelShipThrusterPatches.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 
 namespace QSB.ModelShip.Patches;
 
-internal class ModelShipThrusterPatches : QSBPatch
+public class ModelShipThrusterPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/ModelShip/TransformSync/ModelShipTransformSync.cs
+++ b/QSB/ModelShip/TransformSync/ModelShipTransformSync.cs
@@ -5,7 +5,7 @@ using QSB.WorldSync;
 
 namespace QSB.ModelShip.TransformSync;
 
-internal class ModelShipTransformSync : SectoredRigidbodySync
+public class ModelShipTransformSync : SectoredRigidbodySync
 {
 	public static ModelShipTransformSync LocalInstance { get; private set; }
 

--- a/QSB/Player/Messages/EnterLeaveMessage.cs
+++ b/QSB/Player/Messages/EnterLeaveMessage.cs
@@ -12,7 +12,7 @@ namespace QSB.Player.Messages;
 /// <summary>
 /// todo SendInitialState
 /// </summary>
-internal class EnterLeaveMessage : QSBMessage<EnterLeaveType>
+public class EnterLeaveMessage : QSBMessage<EnterLeaveType>
 {
 	static EnterLeaveMessage()
 	{

--- a/QSB/Player/Messages/LaunchCodesMessage.cs
+++ b/QSB/Player/Messages/LaunchCodesMessage.cs
@@ -3,7 +3,7 @@ using QSB.WorldSync;
 
 namespace QSB.Player.Messages;
 
-internal class LaunchCodesMessage : QSBMessage
+public class LaunchCodesMessage : QSBMessage
 {
 	public override bool ShouldReceive => QSBWorldSync.AllObjectsReady;
 

--- a/QSB/Player/Messages/PlayerEntangledMessage.cs
+++ b/QSB/Player/Messages/PlayerEntangledMessage.cs
@@ -5,7 +5,7 @@ using QSB.WorldSync;
 namespace QSB.Player.Messages;
 
 // almost a world object message, but supports null (-1) as well
-internal class PlayerEntangledMessage : QSBMessage<int>
+public class PlayerEntangledMessage : QSBMessage<int>
 {
 	public PlayerEntangledMessage(int objectId) : base(objectId) { }
 

--- a/QSB/Player/Messages/PlayerJoinMessage.cs
+++ b/QSB/Player/Messages/PlayerJoinMessage.cs
@@ -127,7 +127,7 @@ public class PlayerJoinMessage : QSBMessage
 
 		var player = QSBPlayerManager.GetPlayer(From);
 		player.Name = PlayerName;
-		MultiplayerHUDManager.Instance.WriteMessage(string.Format(QSBLocalization.Current.PlayerJoinedTheGame, player.Name), Color.green);
+		MultiplayerHUDManager.Instance.WriteSystemMessage(string.Format(QSBLocalization.Current.PlayerJoinedTheGame, player.Name), Color.green);
 		DebugLog.DebugWrite($"{player} joined. qsbVersion:{QSBVersion}, gameVersion:{GameVersion}, dlcInstalled:{DlcInstalled}", MessageType.Info);
 	}
 

--- a/QSB/Player/Messages/PlayerJoinMessage.cs
+++ b/QSB/Player/Messages/PlayerJoinMessage.cs
@@ -41,6 +41,7 @@ public class PlayerJoinMessage : QSBMessage
 		}
 
 		AddonHashes = QSBCore.Addons.Keys
+			.Except(QSBCore.CosmeticAddons)
 			.Select(x => x.GetStableHashCode())
 			.ToArray();
 	}
@@ -109,6 +110,7 @@ public class PlayerJoinMessage : QSBMessage
 			}
 
 			var addonHashes = QSBCore.Addons.Keys
+				.Except(QSBCore.CosmeticAddons)
 				.Select(x => x.GetStableHashCode())
 				.ToArray();
 			if (!AddonHashes.SequenceEqual(addonHashes))

--- a/QSB/Player/Messages/PlayerKickMessage.cs
+++ b/QSB/Player/Messages/PlayerKickMessage.cs
@@ -11,7 +11,7 @@ namespace QSB.Player.Messages;
 /// <summary>
 /// always sent by host
 /// </summary>
-internal class PlayerKickMessage : QSBMessage<string>
+public class PlayerKickMessage : QSBMessage<string>
 {
 	private uint PlayerId;
 

--- a/QSB/Player/Messages/PlayerKickMessage.cs
+++ b/QSB/Player/Messages/PlayerKickMessage.cs
@@ -36,15 +36,15 @@ internal class PlayerKickMessage : QSBMessage<string>
 		{
 			if (QSBPlayerManager.PlayerExists(PlayerId))
 			{
-				MultiplayerHUDManager.Instance.WriteMessage(string.Format(QSBLocalization.Current.PlayerWasKicked, QSBPlayerManager.GetPlayer(PlayerId).Name), Color.red);
+				MultiplayerHUDManager.Instance.WriteSystemMessage(string.Format(QSBLocalization.Current.PlayerWasKicked, QSBPlayerManager.GetPlayer(PlayerId).Name), Color.red);
 				return;
 			}
 
-			MultiplayerHUDManager.Instance.WriteMessage(string.Format(QSBLocalization.Current.PlayerWasKicked, PlayerId), Color.red);
+			MultiplayerHUDManager.Instance.WriteSystemMessage(string.Format(QSBLocalization.Current.PlayerWasKicked, PlayerId), Color.red);
 			return;
 		}
 
-		MultiplayerHUDManager.Instance.WriteMessage(string.Format(QSBLocalization.Current.KickedFromServer, Data), Color.red);
+		MultiplayerHUDManager.Instance.WriteSystemMessage(string.Format(QSBLocalization.Current.KickedFromServer, Data), Color.red);
 		MenuManager.Instance.OnKicked(Data);
 
 		NetworkClient.Disconnect();

--- a/QSB/Player/Messages/UpdateFOVMessage.cs
+++ b/QSB/Player/Messages/UpdateFOVMessage.cs
@@ -3,7 +3,7 @@ using QSB.Utility;
 
 namespace QSB.Player.Messages;
 
-internal class UpdateFOVMessage : QSBMessage<float>
+public class UpdateFOVMessage : QSBMessage<float>
 {
 	static UpdateFOVMessage()
 		=> GlobalMessenger<GraphicSettings>.AddListener(

--- a/QSB/Player/Patches/PlayerPatches.cs
+++ b/QSB/Player/Patches/PlayerPatches.cs
@@ -6,7 +6,7 @@ using QSB.Player.Messages;
 namespace QSB.Player.Patches;
 
 [HarmonyPatch]
-internal class PlayerPatches : QSBPatch
+public class PlayerPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/Player/Patches/VolumePatches.cs
+++ b/QSB/Player/Patches/VolumePatches.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace QSB.Player.Patches;
 
-internal class VolumePatches : QSBPatch
+public class VolumePatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/Player/PlayerAttachWatcher.cs
+++ b/QSB/Player/PlayerAttachWatcher.cs
@@ -4,7 +4,7 @@ using QSB.Patches;
 namespace QSB.Player;
 
 [HarmonyPatch(typeof(PlayerAttachPoint))]
-internal class PlayerAttachWatcher : QSBPatch
+public class PlayerAttachWatcher : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnModStart;
 

--- a/QSB/Player/PlayerEntanglementWatcher.cs
+++ b/QSB/Player/PlayerEntanglementWatcher.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 
 namespace QSB.Player;
 
-internal class PlayerEntanglementWatcher : MonoBehaviour, IAddComponentOnStart
+public class PlayerEntanglementWatcher : MonoBehaviour, IAddComponentOnStart
 {
 	private QuantumObject _previousCollidingQuantumObject;
 

--- a/QSB/PlayerBodySetup/Remote/QSBDopplerFixer.cs
+++ b/QSB/PlayerBodySetup/Remote/QSBDopplerFixer.cs
@@ -19,7 +19,7 @@ public class QSBDopplerFixer : MonoBehaviour
 }
 
 [HarmonyPatch(typeof(OWAudioSource))]
-internal class DopplerFixerPatches : QSBPatch
+public class DopplerFixerPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/PoolSync/CustomNomaiRemoteCamera.cs
+++ b/QSB/PoolSync/CustomNomaiRemoteCamera.cs
@@ -2,7 +2,7 @@
 
 namespace QSB.PoolSync;
 
-internal class CustomNomaiRemoteCamera : MonoBehaviour
+public class CustomNomaiRemoteCamera : MonoBehaviour
 {
 	public OWCamera _camera;
 	private AudioListener _audioListener;

--- a/QSB/PoolSync/CustomNomaiRemoteCameraPlatform.cs
+++ b/QSB/PoolSync/CustomNomaiRemoteCameraPlatform.cs
@@ -11,7 +11,7 @@ using UnityEngine;
 
 namespace QSB.PoolSync;
 
-internal class CustomNomaiRemoteCameraPlatform : NomaiShared
+public class CustomNomaiRemoteCameraPlatform : NomaiShared
 {
 	public static List<CustomNomaiRemoteCameraPlatform> CustomPlatformList;
 	private static MaterialPropertyBlock s_matPropBlock;

--- a/QSB/PoolSync/CustomNomaiRemoteCameraStreaming.cs
+++ b/QSB/PoolSync/CustomNomaiRemoteCameraStreaming.cs
@@ -1,6 +1,6 @@
 ﻿namespace QSB.PoolSync;
 
-internal class CustomNomaiRemoteCameraStreaming : SectoredMonoBehaviour
+public class CustomNomaiRemoteCameraStreaming : SectoredMonoBehaviour
 {
 	private CustomNomaiRemoteCameraPlatform _remoteCameraPlatform;
 	private StreamingGroup _streamingGroup;

--- a/QSB/PoolSync/Patches/PoolPatches.cs
+++ b/QSB/PoolSync/Patches/PoolPatches.cs
@@ -4,7 +4,7 @@ using QSB.Patches;
 namespace QSB.PoolSync.Patches;
 
 [HarmonyPatch]
-internal class PoolPatches : QSBPatch
+public class PoolPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/PoolSync/PoolManager.cs
+++ b/QSB/PoolSync/PoolManager.cs
@@ -5,7 +5,7 @@ using System.Threading;
 
 namespace QSB.PoolSync;
 
-internal class PoolManager : WorldObjectManager
+public class PoolManager : WorldObjectManager
 {
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.SolarSystem;
 

--- a/QSB/QSB.csproj
+++ b/QSB/QSB.csproj
@@ -69,7 +69,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="OuterWildsGameLibs" Version="1.1.13.457" IncludeAssets="compile" />
-    <PackageReference Include="OWML" Version="2.9.4" IncludeAssets="compile" />
+    <PackageReference Include="OWML" Version="2.9.5" IncludeAssets="compile" />
     <Reference Include="..\Mirror\*.dll" />
     <Reference Include="..\UniTask\*.dll" />
     <ProjectReference Include="..\EpicOnlineTransport\EpicOnlineTransport.csproj" />

--- a/QSB/QSBCore.cs
+++ b/QSB/QSBCore.cs
@@ -308,32 +308,3 @@ public class QSBCore : ModBehaviour
 		}
 	}
 }
-
-/*
- * _nebula's music thanks
- * I listen to music constantly while programming/working - here's my thanks to them for keeping me entertained :P
- *
- * Wintergatan
- * HOME
- * C418
- * Lupus Nocte
- * Max Cooper
- * Darren Korb
- * Harry Callaghan
- * Toby Fox
- * Andrew Prahlow
- * Valve (Mike Morasky, Kelly Bailey)
- * Joel Nielsen
- * Vulfpeck
- * Detektivbyrån
- * Ben Prunty
- * ConcernedApe
- * Jake Chudnow
- * Murray Gold
- * Teleskärm
- * Daft Punk
- * Natalie Holt
- * WMD
- * Woody Jackson
- * Brian David Gilbert
- */

--- a/QSB/QSBCore.cs
+++ b/QSB/QSBCore.cs
@@ -79,7 +79,7 @@ public class QSBCore : ModBehaviour
 	{
 		// incompatible mods
 		"Raicuparta.NomaiVR",
-		// "xen.NewHorizons",
+		"xen.NewHorizons",
 		"Vesper.AutoResume",
 		"Vesper.OuterWildsMMO",
 		"_nebula.StopTime",

--- a/QSB/QSBCore.cs
+++ b/QSB/QSBCore.cs
@@ -235,7 +235,7 @@ public class QSBCore : ModBehaviour
 	/// This addon MUST NOT send any network messages, or create any worldobjects.
 	/// </summary>
 	/// <param name="addon">The behaviour of the addon.</param>
-	public static void RegisterCosmeticAddon(IModBehaviour addon)
+	public static void RegisterNotRequiredForAllPlayers(IModBehaviour addon)
 	{
 		var uniqueName = addon.ModHelper.Manifest.UniqueName;
 		var addonAssembly = addon.GetType().Assembly;

--- a/QSB/QSBCore.cs
+++ b/QSB/QSBCore.cs
@@ -294,12 +294,12 @@ public class QSBCore : ModBehaviour
 		var compatMod = "";
 		var missingCompat = false;
 
-		if (Helper.Interaction.ModExists(NEW_HORIZONS) && !Helper.Interaction.ModExists(NEW_HORIZONS_COMPAT))
+		/*if (Helper.Interaction.ModExists(NEW_HORIZONS) && !Helper.Interaction.ModExists(NEW_HORIZONS_COMPAT))
 		{
 			mainMod = NEW_HORIZONS;
 			compatMod = NEW_HORIZONS_COMPAT;
 			missingCompat = true;
-		}
+		}*/
 
 		if (missingCompat)
 		{

--- a/QSB/QuantumSync/Messages/EyeProxyMoonStateChangeMessage.cs
+++ b/QSB/QuantumSync/Messages/EyeProxyMoonStateChangeMessage.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace QSB.QuantumSync.Messages;
 
-internal class EyeProxyMoonStateChangeMessage : QSBWorldObjectMessage<QSBEyeProxyQuantumMoon>
+public class EyeProxyMoonStateChangeMessage : QSBWorldObjectMessage<QSBEyeProxyQuantumMoon>
 {
 	private bool Active;
 	private float Angle;

--- a/QSB/QuantumSync/Messages/MoveSkeletonMessage.cs
+++ b/QSB/QuantumSync/Messages/MoveSkeletonMessage.cs
@@ -3,7 +3,7 @@ using QSB.QuantumSync.WorldObjects;
 
 namespace QSB.QuantumSync.Messages;
 
-internal class MoveSkeletonMessage : QSBWorldObjectMessage<QSBQuantumSkeletonTower, int>
+public class MoveSkeletonMessage : QSBWorldObjectMessage<QSBQuantumSkeletonTower, int>
 {
 	public MoveSkeletonMessage(int index) : base(index) { }
 

--- a/QSB/QuantumSync/Messages/MultiStateChangeMessage.cs
+++ b/QSB/QuantumSync/Messages/MultiStateChangeMessage.cs
@@ -5,7 +5,7 @@ using QSB.Utility;
 
 namespace QSB.QuantumSync.Messages;
 
-internal class MultiStateChangeMessage : QSBWorldObjectMessage<QSBMultiStateQuantumObject, int>
+public class MultiStateChangeMessage : QSBWorldObjectMessage<QSBMultiStateQuantumObject, int>
 {
 	public MultiStateChangeMessage(int stateIndex) : base(stateIndex) { }
 

--- a/QSB/QuantumSync/Messages/QuantumShuffleMessage.cs
+++ b/QSB/QuantumSync/Messages/QuantumShuffleMessage.cs
@@ -3,7 +3,7 @@ using QSB.QuantumSync.WorldObjects;
 
 namespace QSB.QuantumSync.Messages;
 
-internal class QuantumShuffleMessage : QSBWorldObjectMessage<QSBQuantumShuffleObject, int[]>
+public class QuantumShuffleMessage : QSBWorldObjectMessage<QSBQuantumShuffleObject, int[]>
 {
 	public QuantumShuffleMessage(int[] indexArray) : base(indexArray) { }
 

--- a/QSB/QuantumSync/Messages/SocketStateChangeMessage.cs
+++ b/QSB/QuantumSync/Messages/SocketStateChangeMessage.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 
 namespace QSB.QuantumSync.Messages;
 
-internal class SocketStateChangeMessage : QSBWorldObjectMessage<QSBSocketedQuantumObject>
+public class SocketStateChangeMessage : QSBWorldObjectMessage<QSBSocketedQuantumObject>
 {
 	private int SocketId;
 	private Quaternion LocalRotation;

--- a/QSB/QuantumSync/Patches/Client/ClientEyeProxyQuantumMoonPatches.cs
+++ b/QSB/QuantumSync/Patches/Client/ClientEyeProxyQuantumMoonPatches.cs
@@ -4,7 +4,7 @@ using QSB.Patches;
 namespace QSB.QuantumSync.Patches.Client;
 
 [HarmonyPatch(typeof(EyeProxyQuantumMoon))]
-internal class ClientEyeProxyQuantumMoonPatches : QSBPatch
+public class ClientEyeProxyQuantumMoonPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnNonServerClientConnect;
 

--- a/QSB/QuantumSync/Patches/Client/ClientQuantumMoonPatches.cs
+++ b/QSB/QuantumSync/Patches/Client/ClientQuantumMoonPatches.cs
@@ -4,7 +4,7 @@ using QSB.Patches;
 namespace QSB.QuantumSync.Patches.Client;
 
 [HarmonyPatch(typeof(QuantumMoon))]
-internal class ClientQuantumMoonPatches : QSBPatch
+public class ClientQuantumMoonPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnNonServerClientConnect;
 

--- a/QSB/QuantumSync/Patches/Common/QuantumMoonPatches.cs
+++ b/QSB/QuantumSync/Patches/Common/QuantumMoonPatches.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 namespace QSB.QuantumSync.Patches.Common;
 
 [HarmonyPatch(typeof(QuantumMoon))]
-internal class QuantumMoonPatches : QSBPatch
+public class QuantumMoonPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/QuantumSync/Patches/Common/QuantumShuffleObjectPatches.cs
+++ b/QSB/QuantumSync/Patches/Common/QuantumShuffleObjectPatches.cs
@@ -11,7 +11,7 @@ using UnityEngine;
 namespace QSB.QuantumSync.Patches.Common;
 
 [HarmonyPatch(typeof(QuantumShuffleObject))]
-internal class QuantumShuffleObjectPatches : QSBPatch
+public class QuantumShuffleObjectPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/QuantumSync/Patches/Common/QuantumSkeletonTowerPatches.cs
+++ b/QSB/QuantumSync/Patches/Common/QuantumSkeletonTowerPatches.cs
@@ -9,7 +9,7 @@ using QSB.WorldSync;
 namespace QSB.QuantumSync.Patches.Common;
 
 [HarmonyPatch(typeof(QuantumSkeletonTower))]
-internal class QuantumSkeletonTowerPatches : QSBPatch
+public class QuantumSkeletonTowerPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/QuantumSync/Patches/Common/QuantumSocketCollapseTriggerPatches.cs
+++ b/QSB/QuantumSync/Patches/Common/QuantumSocketCollapseTriggerPatches.cs
@@ -4,7 +4,7 @@ using QSB.Patches;
 namespace QSB.QuantumSync.Patches.Common;
 
 [HarmonyPatch(typeof(QuantumSocketCollapseTrigger))]
-internal class QuantumSocketCollapseTriggerPatches : QSBPatch
+public class QuantumSocketCollapseTriggerPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/QuantumSync/Patches/Common/Visibility/VisibilityRendererVisibilityTrackerPatches.cs
+++ b/QSB/QuantumSync/Patches/Common/Visibility/VisibilityRendererVisibilityTrackerPatches.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace QSB.QuantumSync.Patches.Common.Visibility;
 
 [HarmonyPatch(typeof(RendererVisibilityTracker))]
-internal class VisibilityRendererVisibilityTrackerPatches : QSBPatch
+public class VisibilityRendererVisibilityTrackerPatches : QSBPatch
 {
     public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/QuantumSync/Patches/Common/Visibility/VisibilityShapePatches.cs
+++ b/QSB/QuantumSync/Patches/Common/Visibility/VisibilityShapePatches.cs
@@ -5,7 +5,7 @@ using QSB.Utility;
 namespace QSB.QuantumSync.Patches.Common.Visibility;
 
 [HarmonyPatch(typeof(Shape))]
-internal class VisibilityShapePatches : QSBPatch
+public class VisibilityShapePatches : QSBPatch
 {
     public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/QuantumSync/Patches/Common/Visibility/VisibilityShapeVisibilityTrackerPatches.cs
+++ b/QSB/QuantumSync/Patches/Common/Visibility/VisibilityShapeVisibilityTrackerPatches.cs
@@ -4,7 +4,7 @@ using QSB.Patches;
 namespace QSB.QuantumSync.Patches.Common.Visibility;
 
 [HarmonyPatch(typeof(ShapeVisibilityTracker))]
-internal class VisibilityShapeVisibilityTrackerPatches : QSBPatch
+public class VisibilityShapeVisibilityTrackerPatches : QSBPatch
 {
     public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/QuantumSync/Patches/Common/Visibility/VisibilityVisibilityObjectPatches.cs
+++ b/QSB/QuantumSync/Patches/Common/Visibility/VisibilityVisibilityObjectPatches.cs
@@ -6,7 +6,7 @@ using System.Linq;
 namespace QSB.QuantumSync.Patches.Common.Visibility;
 
 [HarmonyPatch(typeof(VisibilityObject))]
-internal class VisibilityVisibilityObjectPatches : QSBPatch
+public class VisibilityVisibilityObjectPatches : QSBPatch
 {
     public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/QuantumSync/QuantumManager.cs
+++ b/QSB/QuantumSync/QuantumManager.cs
@@ -13,7 +13,7 @@ using UnityEngine;
 
 namespace QSB.QuantumSync;
 
-internal class QuantumManager : WorldObjectManager
+public class QuantumManager : WorldObjectManager
 {
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.Both;
 

--- a/QSB/QuantumSync/WorldObjects/QSBEyeProxyQuantumMoon.cs
+++ b/QSB/QuantumSync/WorldObjects/QSBEyeProxyQuantumMoon.cs
@@ -1,6 +1,6 @@
 ﻿namespace QSB.QuantumSync.WorldObjects;
 
-internal class QSBEyeProxyQuantumMoon : QSBQuantumObject<EyeProxyQuantumMoon>
+public class QSBEyeProxyQuantumMoon : QSBQuantumObject<EyeProxyQuantumMoon>
 {
 	public override bool HostControls => true;
 

--- a/QSB/QuantumSync/WorldObjects/QSBMultiStateQuantumObject.cs
+++ b/QSB/QuantumSync/WorldObjects/QSBMultiStateQuantumObject.cs
@@ -8,7 +8,7 @@ using System.Threading;
 
 namespace QSB.QuantumSync.WorldObjects;
 
-internal class QSBMultiStateQuantumObject : QSBQuantumObject<MultiStateQuantumObject>
+public class QSBMultiStateQuantumObject : QSBQuantumObject<MultiStateQuantumObject>
 {
 	public List<QSBQuantumState> QuantumStates { get; private set; }
 	public int CurrentState => AttachedObject._stateIndex;

--- a/QSB/QuantumSync/WorldObjects/QSBQuantumMoon.cs
+++ b/QSB/QuantumSync/WorldObjects/QSBQuantumMoon.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace QSB.QuantumSync.WorldObjects;
 
-internal class QSBQuantumMoon : QSBQuantumObject<QuantumMoon>
+public class QSBQuantumMoon : QSBQuantumObject<QuantumMoon>
 {
 	public override bool HostControls => true;
 

--- a/QSB/QuantumSync/WorldObjects/QSBQuantumObject.cs
+++ b/QSB/QuantumSync/WorldObjects/QSBQuantumObject.cs
@@ -18,7 +18,7 @@ namespace QSB.QuantumSync.WorldObjects;
 ///
 /// TODO: make it so only players in the sector (which sector?) are checked for visibility 
 /// </summary>
-internal abstract class QSBQuantumObject<T> : WorldObject<T>, IQSBQuantumObject
+public abstract class QSBQuantumObject<T> : WorldObject<T>, IQSBQuantumObject
 	where T : QuantumObject
 {
 	public virtual bool HostControls => false;

--- a/QSB/QuantumSync/WorldObjects/QSBQuantumShuffleObject.cs
+++ b/QSB/QuantumSync/WorldObjects/QSBQuantumShuffleObject.cs
@@ -1,6 +1,6 @@
 ﻿namespace QSB.QuantumSync.WorldObjects;
 
-internal class QSBQuantumShuffleObject : QSBQuantumObject<QuantumShuffleObject>
+public class QSBQuantumShuffleObject : QSBQuantumObject<QuantumShuffleObject>
 {
 	public override void SendInitialState(uint to)
 	{

--- a/QSB/QuantumSync/WorldObjects/QSBQuantumSkeletonTower.cs
+++ b/QSB/QuantumSync/WorldObjects/QSBQuantumSkeletonTower.cs
@@ -1,6 +1,6 @@
 ﻿namespace QSB.QuantumSync.WorldObjects;
 
-internal class QSBQuantumSkeletonTower : QSBQuantumObject<QuantumSkeletonTower>
+public class QSBQuantumSkeletonTower : QSBQuantumObject<QuantumSkeletonTower>
 {
 	public override string ReturnLabel() => $"{base.ReturnLabel()}"
 	                                        + $"{AttachedObject._index} {AttachedObject._waitForPlayerToLookAtTower}\n"

--- a/QSB/QuantumSync/WorldObjects/QSBQuantumSocket.cs
+++ b/QSB/QuantumSync/WorldObjects/QSBQuantumSocket.cs
@@ -2,7 +2,7 @@
 
 namespace QSB.QuantumSync.WorldObjects;
 
-internal class QSBQuantumSocket : WorldObject<QuantumSocket>
+public class QSBQuantumSocket : WorldObject<QuantumSocket>
 {
 	public override bool ShouldDisplayDebug() => false;
 }

--- a/QSB/QuantumSync/WorldObjects/QSBQuantumState.cs
+++ b/QSB/QuantumSync/WorldObjects/QSBQuantumState.cs
@@ -2,7 +2,7 @@
 
 namespace QSB.QuantumSync.WorldObjects;
 
-internal class QSBQuantumState : WorldObject<QuantumState>
+public class QSBQuantumState : WorldObject<QuantumState>
 {
 	public bool IsMeantToBeEnabled;
 

--- a/QSB/QuantumSync/WorldObjects/QSBSocketedQuantumObject.cs
+++ b/QSB/QuantumSync/WorldObjects/QSBSocketedQuantumObject.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace QSB.QuantumSync.WorldObjects;
 
-internal class QSBSocketedQuantumObject : QSBQuantumObject<SocketedQuantumObject>
+public class QSBSocketedQuantumObject : QSBQuantumObject<SocketedQuantumObject>
 {
 	public override async UniTask Init(CancellationToken ct)
 	{

--- a/QSB/RespawnSync/Messages/PlayerRespawnMessage.cs
+++ b/QSB/RespawnSync/Messages/PlayerRespawnMessage.cs
@@ -4,7 +4,7 @@ using QSB.Player;
 
 namespace QSB.RespawnSync.Messages;
 
-internal class PlayerRespawnMessage : QSBMessage<uint>
+public class PlayerRespawnMessage : QSBMessage<uint>
 {
 	public PlayerRespawnMessage(uint playerId) : base(playerId) { }
 

--- a/QSB/RespawnSync/RespawnManager.cs
+++ b/QSB/RespawnSync/RespawnManager.cs
@@ -12,7 +12,7 @@ using UnityEngine;
 
 namespace QSB.RespawnSync;
 
-internal class RespawnManager : MonoBehaviour, IAddComponentOnStart
+public class RespawnManager : MonoBehaviour, IAddComponentOnStart
 {
 	public static RespawnManager Instance;
 

--- a/QSB/RespawnSync/ShipRecoveryPoint.cs
+++ b/QSB/RespawnSync/ShipRecoveryPoint.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace QSB.RespawnSync;
 
-internal class ShipRecoveryPoint : MonoBehaviour
+public class ShipRecoveryPoint : MonoBehaviour
 {
 	private MultipleInteractionVolume _interactVolume;
 	private PlayerResources _playerResources;

--- a/QSB/RoastingSync/Messages/EnterExitRoastingMessage.cs
+++ b/QSB/RoastingSync/Messages/EnterExitRoastingMessage.cs
@@ -9,7 +9,7 @@ using QSB.WorldSync;
 
 namespace QSB.RoastingSync.Messages;
 
-internal class EnterExitRoastingMessage : QSBMessage<bool>
+public class EnterExitRoastingMessage : QSBMessage<bool>
 {
 	static EnterExitRoastingMessage()
 	{

--- a/QSB/RoastingSync/Messages/MarshmallowEventMessage.cs
+++ b/QSB/RoastingSync/Messages/MarshmallowEventMessage.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace QSB.RoastingSync.Messages;
 
-internal class MarshmallowEventMessage : QSBMessage<MarshmallowMessageType>
+public class MarshmallowEventMessage : QSBMessage<MarshmallowMessageType>
 {
 	public MarshmallowEventMessage(MarshmallowMessageType type) : base(type) { }
 

--- a/QSB/RoastingSync/Patches/RoastingPatches.cs
+++ b/QSB/RoastingSync/Patches/RoastingPatches.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace QSB.RoastingSync.Patches;
 
 [HarmonyPatch]
-internal class RoastingPatches : QSBPatch
+public class RoastingPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/SatelliteSync/Messages/SatelliteProjectorMessage.cs
+++ b/QSB/SatelliteSync/Messages/SatelliteProjectorMessage.cs
@@ -2,7 +2,7 @@
 
 namespace QSB.SatelliteSync.Messages;
 
-internal class SatelliteProjectorMessage : QSBMessage<bool>
+public class SatelliteProjectorMessage : QSBMessage<bool>
 {
 	public SatelliteProjectorMessage(bool usingProjector) : base(usingProjector) { }
 

--- a/QSB/SatelliteSync/Messages/SatelliteProjectorSnapshotMessage.cs
+++ b/QSB/SatelliteSync/Messages/SatelliteProjectorSnapshotMessage.cs
@@ -2,7 +2,7 @@
 
 namespace QSB.SatelliteSync.Messages;
 
-internal class SatelliteProjectorSnapshotMessage : QSBMessage<bool>
+public class SatelliteProjectorSnapshotMessage : QSBMessage<bool>
 {
 	public SatelliteProjectorSnapshotMessage(bool forward) : base(forward) { }
 

--- a/QSB/SatelliteSync/Patches/SatelliteProjectorPatches.cs
+++ b/QSB/SatelliteSync/Patches/SatelliteProjectorPatches.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace QSB.SatelliteSync.Patches;
 
 [HarmonyPatch]
-internal class SatelliteProjectorPatches : QSBPatch
+public class SatelliteProjectorPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/SatelliteSync/SatelliteProjectorManager.cs
+++ b/QSB/SatelliteSync/SatelliteProjectorManager.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace QSB.SatelliteSync;
 
-internal class SatelliteProjectorManager : MonoBehaviour, IAddComponentOnStart
+public class SatelliteProjectorManager : MonoBehaviour, IAddComponentOnStart
 {
 	public static SatelliteProjectorManager Instance { get; private set; }
 

--- a/QSB/SaveSync/Messages/GameStateMessage.cs
+++ b/QSB/SaveSync/Messages/GameStateMessage.cs
@@ -10,7 +10,7 @@ namespace QSB.SaveSync.Messages;
 /// <summary>
 /// always sent by host
 /// </summary>
-internal class GameStateMessage : QSBMessage
+public class GameStateMessage : QSBMessage
 {
 	private bool WarpedToTheEye;
 	private float SecondsRemainingOnWarp;

--- a/QSB/SaveSync/Messages/RequestGameStateMessage.cs
+++ b/QSB/SaveSync/Messages/RequestGameStateMessage.cs
@@ -9,7 +9,7 @@ namespace QSB.SaveSync.Messages;
 /// <summary>
 /// always sent to host
 /// </summary>
-internal class RequestGameStateMessage : QSBMessage
+public class RequestGameStateMessage : QSBMessage
 {
 	public RequestGameStateMessage() => To = 0;
 

--- a/QSB/SaveSync/Messages/ShipLogFactSaveMessage.cs
+++ b/QSB/SaveSync/Messages/ShipLogFactSaveMessage.cs
@@ -3,7 +3,7 @@ using QSB.Messaging;
 
 namespace QSB.SaveSync.Messages;
 
-internal class ShipLogFactSaveMessage : QSBMessage
+public class ShipLogFactSaveMessage : QSBMessage
 {
 	private string _id;
 	private int _revealOrder;

--- a/QSB/SaveSync/Patches/GdkPatches.cs
+++ b/QSB/SaveSync/Patches/GdkPatches.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 namespace QSB.SaveSync.Patches;
 
 [HarmonyPatch(typeof(Gdk))]
-internal class GdkPatches : QSBPatch
+public class GdkPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnModStart;
 	public override GameVendor PatchVendor => GameVendor.Gamepass;

--- a/QSB/SaveSync/Patches/InGameProfileMenuManagerPatches.cs
+++ b/QSB/SaveSync/Patches/InGameProfileMenuManagerPatches.cs
@@ -4,7 +4,7 @@ using QSB.Patches;
 namespace QSB.SaveSync.Patches;
 
 [HarmonyPatch(typeof(InGameProfileMenuManager))]
-internal class InGameProfileMenuManagerPatches : QSBPatch
+public class InGameProfileMenuManagerPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnModStart;
 

--- a/QSB/SaveSync/Patches/PlayerDataPatches.cs
+++ b/QSB/SaveSync/Patches/PlayerDataPatches.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace QSB.SaveSync.Patches;
 
 [HarmonyPatch(typeof(PlayerData))]
-internal class PlayerDataPatches : QSBPatch
+public class PlayerDataPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnModStart;
 

--- a/QSB/SaveSync/Patches/ProfileManagerUpdaterPatches.cs
+++ b/QSB/SaveSync/Patches/ProfileManagerUpdaterPatches.cs
@@ -4,7 +4,7 @@ using QSB.Patches;
 namespace QSB.SaveSync.Patches;
 
 [HarmonyPatch(typeof(ProfileManagerUpdater))]
-internal class ProfileManagerUpdaterPatches : QSBPatch
+public class ProfileManagerUpdaterPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnModStart;
 

--- a/QSB/SaveSync/Patches/ProfileMenuManagerPatches.cs
+++ b/QSB/SaveSync/Patches/ProfileMenuManagerPatches.cs
@@ -7,7 +7,7 @@ using UnityEngine.UI;
 namespace QSB.SaveSync.Patches;
 
 [HarmonyPatch(typeof(ProfileMenuManager))]
-internal class ProfileMenuManagerPatches : QSBPatch
+public class ProfileMenuManagerPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnModStart;
 	public override GameVendor PatchVendor => GameVendor.Epic | GameVendor.Steam;

--- a/QSB/SaveSync/Patches/TitleScreenManagerPatchesCommon.cs
+++ b/QSB/SaveSync/Patches/TitleScreenManagerPatchesCommon.cs
@@ -4,7 +4,7 @@ using QSB.Patches;
 namespace QSB.SaveSync.Patches;
 
 [HarmonyPatch(typeof(TitleScreenManager))]
-internal class TitleScreenManagerPatchesCommon : QSBPatch
+public class TitleScreenManagerPatchesCommon : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnModStart;
 

--- a/QSB/SaveSync/Patches/TitleScreenManagerPatchesGamepass.cs
+++ b/QSB/SaveSync/Patches/TitleScreenManagerPatchesGamepass.cs
@@ -6,7 +6,7 @@ using UnityEngine.UI;
 namespace QSB.SaveSync.Patches;
 
 [HarmonyPatch(typeof(TitleScreenManager))]
-internal class TitleScreenManagerPatchesGamepass : QSBPatch
+public class TitleScreenManagerPatchesGamepass : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnModStart;
 	public override GameVendor PatchVendor => GameVendor.Gamepass;

--- a/QSB/SaveSync/Patches/TitleScreenManagerPatchesStandalone.cs
+++ b/QSB/SaveSync/Patches/TitleScreenManagerPatchesStandalone.cs
@@ -4,7 +4,7 @@ using QSB.Patches;
 namespace QSB.SaveSync.Patches;
 
 [HarmonyPatch(typeof(TitleScreenManager))]
-internal class TitleScreenManagerPatchesStandalone : QSBPatch
+public class TitleScreenManagerPatchesStandalone : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnModStart;
 	public override GameVendor PatchVendor => GameVendor.Epic | GameVendor.Steam;

--- a/QSB/SaveSync/QSBMSStoreProfileManager.cs
+++ b/QSB/SaveSync/QSBMSStoreProfileManager.cs
@@ -10,7 +10,7 @@ using UnityEngine.InputSystem;
 
 namespace QSB.SaveSync;
 
-internal class QSBMSStoreProfileManager : IProfileManager
+public class QSBMSStoreProfileManager : IProfileManager
 {
 	private const string OW_SAVE_CONTAINER_NAME = "GameSave";
 	private const string OW_GAME_SAVE_BLOB_NAME = "Outer Wilds Converted";

--- a/QSB/SaveSync/QSBStandaloneProfileManager.cs
+++ b/QSB/SaveSync/QSBStandaloneProfileManager.cs
@@ -10,7 +10,7 @@ using UnityEngine;
 
 namespace QSB.SaveSync;
 
-internal class QSBStandaloneProfileManager : IProfileManager
+public class QSBStandaloneProfileManager : IProfileManager
 {
 	private static QSBStandaloneProfileManager s_instance;
 

--- a/QSB/ServerSettings/ServerSettingsManager.cs
+++ b/QSB/ServerSettings/ServerSettingsManager.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace QSB.ServerSettings;
 
-internal class ServerSettingsManager : MonoBehaviour, IAddComponentOnStart
+public class ServerSettingsManager : MonoBehaviour, IAddComponentOnStart
 {
 	public static bool ServerShowPlayerNames;
 	public static bool ShowPlayerNames => (ServerShowPlayerNames || QSBCore.IsHost) && QSBCore.ShowPlayerNames;

--- a/QSB/ServerSettings/ServerSettingsMessage.cs
+++ b/QSB/ServerSettings/ServerSettingsMessage.cs
@@ -3,7 +3,7 @@ using QSB.Messaging;
 
 namespace QSB.ServerSettings;
 
-internal class ServerSettingsMessage : QSBMessage
+public class ServerSettingsMessage : QSBMessage
 {
 	private bool _showPlayerNames;
 

--- a/QSB/ShipSync/Messages/Component/ComponentDamagedMessage.cs
+++ b/QSB/ShipSync/Messages/Component/ComponentDamagedMessage.cs
@@ -3,7 +3,7 @@ using QSB.ShipSync.WorldObjects;
 
 namespace QSB.ShipSync.Messages.Component;
 
-internal class ComponentDamagedMessage : QSBWorldObjectMessage<QSBShipComponent>
+public class ComponentDamagedMessage : QSBWorldObjectMessage<QSBShipComponent>
 {
 	public override void OnReceiveRemote() => WorldObject.SetDamaged();
 }

--- a/QSB/ShipSync/Messages/Component/ComponentRepairTickMessage.cs
+++ b/QSB/ShipSync/Messages/Component/ComponentRepairTickMessage.cs
@@ -3,7 +3,7 @@ using QSB.ShipSync.WorldObjects;
 
 namespace QSB.ShipSync.Messages.Component;
 
-internal class ComponentRepairTickMessage : QSBWorldObjectMessage<QSBShipComponent, float>
+public class ComponentRepairTickMessage : QSBWorldObjectMessage<QSBShipComponent, float>
 {
 	public ComponentRepairTickMessage(float repairFraction) : base(repairFraction) { }
 

--- a/QSB/ShipSync/Messages/Component/ComponentRepairedMessage.cs
+++ b/QSB/ShipSync/Messages/Component/ComponentRepairedMessage.cs
@@ -3,7 +3,7 @@ using QSB.ShipSync.WorldObjects;
 
 namespace QSB.ShipSync.Messages.Component;
 
-internal class ComponentRepairedMessage : QSBWorldObjectMessage<QSBShipComponent>
+public class ComponentRepairedMessage : QSBWorldObjectMessage<QSBShipComponent>
 {
 	public override void OnReceiveRemote() => WorldObject.SetRepaired();
 }

--- a/QSB/ShipSync/Messages/FlyShipMessage.cs
+++ b/QSB/ShipSync/Messages/FlyShipMessage.cs
@@ -11,7 +11,7 @@ namespace QSB.ShipSync.Messages;
 /// <summary>
 /// TODO: initial state for the current flyer
 /// </summary>
-internal class FlyShipMessage : QSBMessage<bool>
+public class FlyShipMessage : QSBMessage<bool>
 {
 	static FlyShipMessage()
 	{

--- a/QSB/ShipSync/Messages/FunnelEnableMessage.cs
+++ b/QSB/ShipSync/Messages/FunnelEnableMessage.cs
@@ -3,7 +3,7 @@ using QSB.WorldSync;
 
 namespace QSB.ShipSync.Messages;
 
-internal class FunnelEnableMessage : QSBMessage
+public class FunnelEnableMessage : QSBMessage
 {
 	public override bool ShouldReceive => QSBWorldSync.AllObjectsReady;
 

--- a/QSB/ShipSync/Messages/HatchMessage.cs
+++ b/QSB/ShipSync/Messages/HatchMessage.cs
@@ -3,7 +3,7 @@ using QSB.WorldSync;
 
 namespace QSB.ShipSync.Messages;
 
-internal class HatchMessage : QSBMessage<bool>
+public class HatchMessage : QSBMessage<bool>
 {
 	public HatchMessage(bool open) : base(open) { }
 

--- a/QSB/ShipSync/Messages/Hull/HullChangeIntegrityMessage.cs
+++ b/QSB/ShipSync/Messages/Hull/HullChangeIntegrityMessage.cs
@@ -3,7 +3,7 @@ using QSB.ShipSync.WorldObjects;
 
 namespace QSB.ShipSync.Messages.Hull;
 
-internal class HullChangeIntegrityMessage : QSBWorldObjectMessage<QSBShipHull, float>
+public class HullChangeIntegrityMessage : QSBWorldObjectMessage<QSBShipHull, float>
 {
 	public HullChangeIntegrityMessage(float integrity) : base(integrity) { }
 

--- a/QSB/ShipSync/Messages/Hull/HullDamagedMessage.cs
+++ b/QSB/ShipSync/Messages/Hull/HullDamagedMessage.cs
@@ -3,7 +3,7 @@ using QSB.ShipSync.WorldObjects;
 
 namespace QSB.ShipSync.Messages.Hull;
 
-internal class HullDamagedMessage : QSBWorldObjectMessage<QSBShipHull>
+public class HullDamagedMessage : QSBWorldObjectMessage<QSBShipHull>
 {
 	public override void OnReceiveRemote() => WorldObject.SetDamaged();
 }

--- a/QSB/ShipSync/Messages/Hull/HullRepairedMessage.cs
+++ b/QSB/ShipSync/Messages/Hull/HullRepairedMessage.cs
@@ -3,7 +3,7 @@ using QSB.ShipSync.WorldObjects;
 
 namespace QSB.ShipSync.Messages.Hull;
 
-internal class HullRepairedMessage : QSBWorldObjectMessage<QSBShipHull>
+public class HullRepairedMessage : QSBWorldObjectMessage<QSBShipHull>
 {
 	public override void OnReceiveRemote() => WorldObject.SetRepaired();
 }

--- a/QSB/ShipSync/Messages/LandingCameraMessage.cs
+++ b/QSB/ShipSync/Messages/LandingCameraMessage.cs
@@ -3,7 +3,7 @@ using QSB.Utility;
 
 namespace QSB.ShipSync.Messages;
 
-internal class LandingCameraMessage : QSBMessage<bool>
+public class LandingCameraMessage : QSBMessage<bool>
 {
 	public LandingCameraMessage(bool on) : base(on) { }
 

--- a/QSB/ShipSync/Messages/LegDetachMessage.cs
+++ b/QSB/ShipSync/Messages/LegDetachMessage.cs
@@ -3,7 +3,7 @@ using QSB.ShipSync.WorldObjects;
 
 namespace QSB.ShipSync.Messages;
 
-internal class LegDetachMessage : QSBWorldObjectMessage<QSBShipDetachableLeg>
+public class LegDetachMessage : QSBWorldObjectMessage<QSBShipDetachableLeg>
 {
 	public override void OnReceiveRemote() =>
 		WorldObject.AttachedObject.Detach();

--- a/QSB/ShipSync/Messages/ModuleDetachMessage.cs
+++ b/QSB/ShipSync/Messages/ModuleDetachMessage.cs
@@ -3,7 +3,7 @@ using QSB.ShipSync.WorldObjects;
 
 namespace QSB.ShipSync.Messages;
 
-internal class ModuleDetachMessage : QSBWorldObjectMessage<QSBShipDetachableModule>
+public class ModuleDetachMessage : QSBWorldObjectMessage<QSBShipDetachableModule>
 {
 	public override void OnReceiveRemote() =>
 		WorldObject.AttachedObject.Detach();

--- a/QSB/ShipSync/Messages/ReactorCountdownMessage.cs
+++ b/QSB/ShipSync/Messages/ReactorCountdownMessage.cs
@@ -3,7 +3,7 @@ using QSB.WorldSync;
 
 namespace QSB.ShipSync.Messages;
 
-internal class ReactorCountdownMessage : QSBMessage<float>
+public class ReactorCountdownMessage : QSBMessage<float>
 {
 	public ReactorCountdownMessage(float countdown) : base(countdown) { }
 

--- a/QSB/ShipSync/Messages/ShipIgnitionMessage.cs
+++ b/QSB/ShipSync/Messages/ShipIgnitionMessage.cs
@@ -5,7 +5,7 @@ using static QSB.ShipSync.Messages.ShipIgnitionMessage;
 
 namespace QSB.ShipSync.Messages;
 
-internal class ShipIgnitionMessage : QSBMessage<ShipIgnitionType>
+public class ShipIgnitionMessage : QSBMessage<ShipIgnitionType>
 {
     public enum ShipIgnitionType
     {

--- a/QSB/ShipSync/Messages/ShipLightMessage.cs
+++ b/QSB/ShipSync/Messages/ShipLightMessage.cs
@@ -3,7 +3,7 @@ using QSB.ShipSync.WorldObjects;
 
 namespace QSB.ShipSync.Messages;
 
-internal class ShipLightMessage : QSBWorldObjectMessage<QSBShipLight, bool>
+public class ShipLightMessage : QSBWorldObjectMessage<QSBShipLight, bool>
 {
 	public ShipLightMessage(bool on) : base(on) { }
 

--- a/QSB/ShipSync/TransformSync/ShipLegTransformSync.cs
+++ b/QSB/ShipSync/TransformSync/ShipLegTransformSync.cs
@@ -5,7 +5,7 @@ using QSB.WorldSync;
 
 namespace QSB.ShipSync.TransformSync;
 
-internal class ShipLegTransformSync : SectoredRigidbodySync, ILinkedNetworkBehaviour
+public class ShipLegTransformSync : SectoredRigidbodySync, ILinkedNetworkBehaviour
 {
 	/// <summary>
 	/// normally prints error when attached object is null.

--- a/QSB/ShipSync/TransformSync/ShipModuleTransformSync.cs
+++ b/QSB/ShipSync/TransformSync/ShipModuleTransformSync.cs
@@ -5,7 +5,7 @@ using QSB.WorldSync;
 
 namespace QSB.ShipSync.TransformSync;
 
-internal class ShipModuleTransformSync : SectoredRigidbodySync, ILinkedNetworkBehaviour
+public class ShipModuleTransformSync : SectoredRigidbodySync, ILinkedNetworkBehaviour
 {
 	/// <summary>
 	/// normally prints error when attached object is null.

--- a/QSB/ShipSync/WorldObjects/QSBShipComponent.cs
+++ b/QSB/ShipSync/WorldObjects/QSBShipComponent.cs
@@ -5,7 +5,7 @@ using QSB.WorldSync;
 
 namespace QSB.ShipSync.WorldObjects;
 
-internal class QSBShipComponent : WorldObject<ShipComponent>
+public class QSBShipComponent : WorldObject<ShipComponent>
 {
 	public override void SendInitialState(uint to)
 	{

--- a/QSB/ShipSync/WorldObjects/QSBShipDetachableLeg.cs
+++ b/QSB/ShipSync/WorldObjects/QSBShipDetachableLeg.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace QSB.ShipSync.WorldObjects;
 
-internal class QSBShipDetachableLeg : LinkedWorldObject<ShipDetachableLeg, ShipLegTransformSync>
+public class QSBShipDetachableLeg : LinkedWorldObject<ShipDetachableLeg, ShipLegTransformSync>
 {
 	protected override GameObject NetworkObjectPrefab => QSBNetworkManager.singleton.ShipLegPrefab;
 	protected override bool SpawnWithServerOwnership => true;

--- a/QSB/ShipSync/WorldObjects/QSBShipDetachableModule.cs
+++ b/QSB/ShipSync/WorldObjects/QSBShipDetachableModule.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace QSB.ShipSync.WorldObjects;
 
-internal class QSBShipDetachableModule : LinkedWorldObject<ShipDetachableModule, ShipModuleTransformSync>
+public class QSBShipDetachableModule : LinkedWorldObject<ShipDetachableModule, ShipModuleTransformSync>
 {
 	protected override GameObject NetworkObjectPrefab => QSBNetworkManager.singleton.ShipModulePrefab;
 	protected override bool SpawnWithServerOwnership => true;

--- a/QSB/ShipSync/WorldObjects/QSBShipHull.cs
+++ b/QSB/ShipSync/WorldObjects/QSBShipHull.cs
@@ -5,7 +5,7 @@ using QSB.WorldSync;
 
 namespace QSB.ShipSync.WorldObjects;
 
-internal class QSBShipHull : WorldObject<ShipHull>
+public class QSBShipHull : WorldObject<ShipHull>
 {
 	public override void SendInitialState(uint to)
 	{

--- a/QSB/ShipSync/WorldObjects/QSBShipLight.cs
+++ b/QSB/ShipSync/WorldObjects/QSBShipLight.cs
@@ -4,7 +4,7 @@ using QSB.WorldSync;
 
 namespace QSB.ShipSync.WorldObjects;
 
-internal class QSBShipLight : WorldObject<ShipLight>
+public class QSBShipLight : WorldObject<ShipLight>
 {
 	public override void SendInitialState(uint to) =>
 		this.SendMessage(new ShipLightMessage(AttachedObject._on) { To = to });

--- a/QSB/StatueSync/Messages/StartStatueMessage.cs
+++ b/QSB/StatueSync/Messages/StartStatueMessage.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 
 namespace QSB.StatueSync.Messages;
 
-internal class StartStatueMessage : QSBMessage
+public class StartStatueMessage : QSBMessage
 {
 	private Vector3 PlayerPosition;
 	private Quaternion PlayerRotation;

--- a/QSB/StatueSync/Patches/StatuePatches.cs
+++ b/QSB/StatueSync/Patches/StatuePatches.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 namespace QSB.StatueSync.Patches;
 
 [HarmonyPatch]
-internal class StatuePatches : QSBPatch
+public class StatuePatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/StatueSync/StatueManager.cs
+++ b/QSB/StatueSync/StatueManager.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace QSB.StatueSync;
 
-internal class StatueManager : MonoBehaviour, IAddComponentOnStart
+public class StatueManager : MonoBehaviour, IAddComponentOnStart
 {
 	public static StatueManager Instance { get; private set; }
 	public bool HasStartedStatueLocally;

--- a/QSB/Syncs/Occasional/OccasionalManager.cs
+++ b/QSB/Syncs/Occasional/OccasionalManager.cs
@@ -8,7 +8,7 @@ using System.Threading;
 
 namespace QSB.Syncs.Occasional;
 
-internal class OccasionalManager : WorldObjectManager
+public class OccasionalManager : WorldObjectManager
 {
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.SolarSystem;
 

--- a/QSB/TimeSync/Patches/TimePatches.cs
+++ b/QSB/TimeSync/Patches/TimePatches.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 namespace QSB.TimeSync.Patches;
 
 [HarmonyPatch]
-internal class TimePatches : QSBPatch
+public class TimePatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 
@@ -44,7 +44,7 @@ internal class TimePatches : QSBPatch
 		=> OWInput.ChangeInputMode(InputMode.Character);
 }
 
-internal class ClientTimePatches : QSBPatch
+public class ClientTimePatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnNonServerClientConnect;
 

--- a/QSB/TimeSync/TimeSyncUI.cs
+++ b/QSB/TimeSync/TimeSyncUI.cs
@@ -8,7 +8,7 @@ using UnityEngine.UI;
 
 namespace QSB.TimeSync;
 
-internal class TimeSyncUI : MonoBehaviour, IAddComponentOnStart
+public class TimeSyncUI : MonoBehaviour, IAddComponentOnStart
 {
 	private static TimeSyncUI _instance;
 

--- a/QSB/Tools/FlashlightTool/FlashlightCreator.cs
+++ b/QSB/Tools/FlashlightTool/FlashlightCreator.cs
@@ -2,7 +2,7 @@
 
 namespace QSB.Tools.FlashlightTool;
 
-internal static class FlashlightCreator
+public static class FlashlightCreator
 {
 	internal static void CreateFlashlight(PlayerInfo player)
 	{

--- a/QSB/Tools/ProbeLauncherTool/Messages/ChangeModeMessage.cs
+++ b/QSB/Tools/ProbeLauncherTool/Messages/ChangeModeMessage.cs
@@ -3,7 +3,7 @@ using QSB.Tools.ProbeLauncherTool.WorldObjects;
 
 namespace QSB.Tools.ProbeLauncherTool.Messages;
 
-internal class ChangeModeMessage : QSBWorldObjectMessage<QSBProbeLauncher>
+public class ChangeModeMessage : QSBWorldObjectMessage<QSBProbeLauncher>
 {
 	public ChangeModeMessage() : base() { }
 

--- a/QSB/Tools/ProbeLauncherTool/Messages/LaunchProbeMessage.cs
+++ b/QSB/Tools/ProbeLauncherTool/Messages/LaunchProbeMessage.cs
@@ -3,7 +3,7 @@ using QSB.Tools.ProbeLauncherTool.WorldObjects;
 
 namespace QSB.Tools.ProbeLauncherTool.Messages;
 
-internal class LaunchProbeMessage : QSBWorldObjectMessage<QSBProbeLauncher, (bool playEffects, uint probeOwnerID)>
+public class LaunchProbeMessage : QSBWorldObjectMessage<QSBProbeLauncher, (bool playEffects, uint probeOwnerID)>
 {
 	public LaunchProbeMessage(bool playEffects, uint probeOwnerID) : base((playEffects, probeOwnerID)) { }
 

--- a/QSB/Tools/ProbeLauncherTool/Messages/PlayerEquipLauncherMessage.cs
+++ b/QSB/Tools/ProbeLauncherTool/Messages/PlayerEquipLauncherMessage.cs
@@ -3,7 +3,7 @@ using QSB.Player;
 
 namespace QSB.Tools.ProbeLauncherTool.Messages;
 
-internal class PlayerEquipLauncherMessage : QSBMessage<bool>
+public class PlayerEquipLauncherMessage : QSBMessage<bool>
 {
 	public PlayerEquipLauncherMessage(bool equipped) : base(equipped) { }
 

--- a/QSB/Tools/ProbeLauncherTool/Messages/PlayerLaunchProbeMessage.cs
+++ b/QSB/Tools/ProbeLauncherTool/Messages/PlayerLaunchProbeMessage.cs
@@ -4,7 +4,7 @@ using QSB.WorldSync;
 
 namespace QSB.Tools.ProbeLauncherTool.Messages;
 
-internal class PlayerLaunchProbeMessage : QSBMessage
+public class PlayerLaunchProbeMessage : QSBMessage
 {
 	public override bool ShouldReceive => QSBWorldSync.AllObjectsReady;
 

--- a/QSB/Tools/ProbeLauncherTool/Messages/PlayerLauncherChangeModeMessage.cs
+++ b/QSB/Tools/ProbeLauncherTool/Messages/PlayerLauncherChangeModeMessage.cs
@@ -4,7 +4,7 @@ using QSB.WorldSync;
 
 namespace QSB.Tools.ProbeLauncherTool.Messages;
 
-internal class PlayerLauncherChangeModeMessage : QSBMessage
+public class PlayerLauncherChangeModeMessage : QSBMessage
 {
 	public override bool ShouldReceive => QSBWorldSync.AllObjectsReady;
 

--- a/QSB/Tools/ProbeLauncherTool/Messages/PlayerLauncherTakeSnapshotMessage.cs
+++ b/QSB/Tools/ProbeLauncherTool/Messages/PlayerLauncherTakeSnapshotMessage.cs
@@ -5,7 +5,7 @@ using QSB.WorldSync;
 
 namespace QSB.Tools.ProbeLauncherTool.Messages;
 
-internal class PlayerLauncherTakeSnapshotMessage : QSBMessage<ProbeCamera.ID>
+public class PlayerLauncherTakeSnapshotMessage : QSBMessage<ProbeCamera.ID>
 {
 	public PlayerLauncherTakeSnapshotMessage(ProbeCamera.ID cameraId) : base(cameraId) { }
 

--- a/QSB/Tools/ProbeLauncherTool/Messages/PlayerRetrieveProbeMessage.cs
+++ b/QSB/Tools/ProbeLauncherTool/Messages/PlayerRetrieveProbeMessage.cs
@@ -4,7 +4,7 @@ using QSB.WorldSync;
 
 namespace QSB.Tools.ProbeLauncherTool.Messages;
 
-internal class PlayerRetrieveProbeMessage : QSBMessage<bool>
+public class PlayerRetrieveProbeMessage : QSBMessage<bool>
 {
 	public PlayerRetrieveProbeMessage(bool playEffects) : base(playEffects) { }
 

--- a/QSB/Tools/ProbeLauncherTool/Messages/RemoveSnapshotMessage.cs
+++ b/QSB/Tools/ProbeLauncherTool/Messages/RemoveSnapshotMessage.cs
@@ -5,7 +5,7 @@ using QSB.QuantumSync;
 
 namespace QSB.Tools.ProbeLauncherTool.Messages;
 
-internal class RemoveSnapshotMessage : QSBMessage
+public class RemoveSnapshotMessage : QSBMessage
 {
 	static RemoveSnapshotMessage()
 		=> GlobalMessenger.AddListener(OWEvents.ProbeSnapshotRemoved, Handle);

--- a/QSB/Tools/ProbeLauncherTool/Messages/RetrieveProbeMessage.cs
+++ b/QSB/Tools/ProbeLauncherTool/Messages/RetrieveProbeMessage.cs
@@ -3,7 +3,7 @@ using QSB.Tools.ProbeLauncherTool.WorldObjects;
 
 namespace QSB.Tools.ProbeLauncherTool.Messages;
 
-internal class RetrieveProbeMessage : QSBWorldObjectMessage<QSBProbeLauncher, bool>
+public class RetrieveProbeMessage : QSBWorldObjectMessage<QSBProbeLauncher, bool>
 {
 	public RetrieveProbeMessage(bool playEffects) : base(playEffects) { }
 

--- a/QSB/Tools/ProbeLauncherTool/Messages/TakeSnapshotMessage.cs
+++ b/QSB/Tools/ProbeLauncherTool/Messages/TakeSnapshotMessage.cs
@@ -5,7 +5,7 @@ using QSB.Tools.ProbeLauncherTool.WorldObjects;
 
 namespace QSB.Tools.ProbeLauncherTool.Messages;
 
-internal class TakeSnapshotMessage : QSBWorldObjectMessage<QSBProbeLauncher, ProbeCamera.ID>
+public class TakeSnapshotMessage : QSBWorldObjectMessage<QSBProbeLauncher, ProbeCamera.ID>
 {
 	public TakeSnapshotMessage(ProbeCamera.ID cameraId) : base(cameraId) { }
 

--- a/QSB/Tools/ProbeLauncherTool/Patches/LauncherPatches.cs
+++ b/QSB/Tools/ProbeLauncherTool/Patches/LauncherPatches.cs
@@ -10,7 +10,7 @@ using QSB.WorldSync;
 namespace QSB.Tools.ProbeLauncherTool.Patches;
 
 [HarmonyPatch]
-internal class LauncherPatches : QSBPatch
+public class LauncherPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/Tools/ProbeLauncherTool/ProbeLauncherCreator.cs
+++ b/QSB/Tools/ProbeLauncherTool/ProbeLauncherCreator.cs
@@ -2,7 +2,7 @@
 
 namespace QSB.Tools.ProbeLauncherTool;
 
-internal static class ProbeLauncherCreator
+public static class ProbeLauncherCreator
 {
 	internal static void CreateProbeLauncher(PlayerInfo player)
 	{

--- a/QSB/Tools/ProbeLauncherTool/ProbeLauncherListener.cs
+++ b/QSB/Tools/ProbeLauncherTool/ProbeLauncherListener.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace QSB.Tools.ProbeLauncherTool;
 
-internal class ProbeLauncherListener : MonoBehaviour
+public class ProbeLauncherListener : MonoBehaviour
 {
 	private PlayerProbeLauncher _attachedLauncher;
 

--- a/QSB/Tools/ProbeLauncherTool/ProbeLauncherManager.cs
+++ b/QSB/Tools/ProbeLauncherTool/ProbeLauncherManager.cs
@@ -7,7 +7,7 @@ using System.Threading;
 
 namespace QSB.Tools.ProbeLauncherTool;
 
-internal class ProbeLauncherManager : WorldObjectManager
+public class ProbeLauncherManager : WorldObjectManager
 {
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.Both;
 

--- a/QSB/Tools/ProbeTool/Messages/PlayerProbeEventMessage.cs
+++ b/QSB/Tools/ProbeTool/Messages/PlayerProbeEventMessage.cs
@@ -4,7 +4,7 @@ using QSB.WorldSync;
 
 namespace QSB.Tools.ProbeTool.Messages;
 
-internal class PlayerProbeEventMessage : QSBMessage<ProbeEvent>
+public class PlayerProbeEventMessage : QSBMessage<ProbeEvent>
 {
 	public PlayerProbeEventMessage(ProbeEvent probeEvent) : base(probeEvent) { }
 

--- a/QSB/Tools/ProbeTool/Messages/ProbeEnterLeaveMessage.cs
+++ b/QSB/Tools/ProbeTool/Messages/ProbeEnterLeaveMessage.cs
@@ -12,7 +12,7 @@ using QSB.Utility;
 
 namespace QSB.Tools.ProbeTool.Messages;
 
-internal class ProbeEnterLeaveMessage : QSBMessage<ProbeEnterLeaveType>
+public class ProbeEnterLeaveMessage : QSBMessage<ProbeEnterLeaveType>
 {
 	static ProbeEnterLeaveMessage()
 	{

--- a/QSB/Tools/ProbeTool/Messages/ProbeStartRetrieveMessage.cs
+++ b/QSB/Tools/ProbeTool/Messages/ProbeStartRetrieveMessage.cs
@@ -4,7 +4,7 @@ using QSB.WorldSync;
 
 namespace QSB.Tools.ProbeTool.Messages;
 
-internal class ProbeStartRetrieveMessage : QSBMessage<float>
+public class ProbeStartRetrieveMessage : QSBMessage<float>
 {
 	public ProbeStartRetrieveMessage(float duration) : base(duration) { }
 

--- a/QSB/Tools/ProbeTool/Messages/RotateProbeMessage.cs
+++ b/QSB/Tools/ProbeTool/Messages/RotateProbeMessage.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace QSB.Tools.ProbeTool.Messages;
 
-internal class RotateProbeMessage : QSBMessage<(RotationType rotationType, Vector2 cameraRotation)>
+public class RotateProbeMessage : QSBMessage<(RotationType rotationType, Vector2 cameraRotation)>
 {
 	public RotateProbeMessage(RotationType rotationType, Vector2 cameraRotation) : base((rotationType, cameraRotation)) { }
 

--- a/QSB/Tools/ProbeTool/Patches/ProbeToolPatches.cs
+++ b/QSB/Tools/ProbeTool/Patches/ProbeToolPatches.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 
 namespace QSB.Tools.ProbeTool.Patches;
 
-internal class ProbeToolPatches : QSBPatch
+public class ProbeToolPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/Tools/ProbeTool/ProbeCreator.cs
+++ b/QSB/Tools/ProbeTool/ProbeCreator.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace QSB.Tools.ProbeTool;
 
-internal static class ProbeCreator
+public static class ProbeCreator
 {
 	private static GameObject _prefab;
 

--- a/QSB/Tools/ProbeTool/ProbeListener.cs
+++ b/QSB/Tools/ProbeTool/ProbeListener.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace QSB.Tools.ProbeTool;
 
-internal class ProbeListener : MonoBehaviour
+public class ProbeListener : MonoBehaviour
 {
 	private SurveyorProbe _attachedProbe;
 

--- a/QSB/Tools/ProbeTool/QSBProbeAnimatorController.cs
+++ b/QSB/Tools/ProbeTool/QSBProbeAnimatorController.cs
@@ -3,7 +3,7 @@
 namespace QSB.Tools.ProbeTool;
 
 [RequireComponent(typeof(Animator))]
-internal class QSBProbeAnimatorController : MonoBehaviour
+public class QSBProbeAnimatorController : MonoBehaviour
 {
 	private Animator _animator;
 	private QSBSurveyorProbe _probe;

--- a/QSB/Tools/ProbeTool/QSBProbeEffects.cs
+++ b/QSB/Tools/ProbeTool/QSBProbeEffects.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace QSB.Tools.ProbeTool;
 
 [UsedInUnityProject]
-internal class QSBProbeEffects : MonoBehaviour
+public class QSBProbeEffects : MonoBehaviour
 {
 	public OWAudioSource _flightLoopAudio;
 	public OWAudioSource _anchorAudio;

--- a/QSB/Tools/ProbeTool/QSBProbeLantern.cs
+++ b/QSB/Tools/ProbeTool/QSBProbeLantern.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace QSB.Tools.ProbeTool;
 
 [UsedInUnityProject]
-internal class QSBProbeLantern : MonoBehaviour
+public class QSBProbeLantern : MonoBehaviour
 {
 	public float _fadeInDuration;
 	public AnimationCurve _fadeInCurve;

--- a/QSB/Tools/ProbeTool/QSBProbeSpotlight.cs
+++ b/QSB/Tools/ProbeTool/QSBProbeSpotlight.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace QSB.Tools.ProbeTool;
 
 [UsedInUnityProject]
-internal class QSBProbeSpotlight : MonoBehaviour
+public class QSBProbeSpotlight : MonoBehaviour
 {
 	public ProbeCamera.ID _id;
 	public float _fadeInLength = 1f;

--- a/QSB/Tools/SignalscopeTool/SignalscopeCreator.cs
+++ b/QSB/Tools/SignalscopeTool/SignalscopeCreator.cs
@@ -2,7 +2,7 @@
 
 namespace QSB.Tools.SignalscopeTool;
 
-internal static class SignalscopeCreator
+public static class SignalscopeCreator
 {
 	internal static void CreateSignalscope(PlayerInfo player)
 	{

--- a/QSB/Tools/TranslatorTool/Messages/IsTranslatingMessage.cs
+++ b/QSB/Tools/TranslatorTool/Messages/IsTranslatingMessage.cs
@@ -3,7 +3,7 @@ using QSB.Player;
 
 namespace QSB.Tools.TranslatorTool.Messages;
 
-internal class IsTranslatingMessage : QSBMessage<bool>
+public class IsTranslatingMessage : QSBMessage<bool>
 {
 	public IsTranslatingMessage(bool translating) : base(translating) { }
 

--- a/QSB/Tools/TranslatorTool/Messages/TranslatorScrollMessage.cs
+++ b/QSB/Tools/TranslatorTool/Messages/TranslatorScrollMessage.cs
@@ -3,7 +3,7 @@ using QSB.Player;
 
 namespace QSB.Tools.TranslatorTool.Messages;
 
-internal class TranslatorScrollMessage : QSBMessage<float>
+public class TranslatorScrollMessage : QSBMessage<float>
 {
 	public TranslatorScrollMessage(float scrollPos) : base(scrollPos) { }
 

--- a/QSB/Tools/TranslatorTool/Patches/TranslatorPatches.cs
+++ b/QSB/Tools/TranslatorTool/Patches/TranslatorPatches.cs
@@ -11,7 +11,7 @@ using UnityEngine;
 
 namespace QSB.Tools.TranslatorTool.Patches;
 
-internal class TranslatorPatches : QSBPatch
+public class TranslatorPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/Tools/TranslatorTool/QSBNomaiTranslatorProp.cs
+++ b/QSB/Tools/TranslatorTool/QSBNomaiTranslatorProp.cs
@@ -7,7 +7,7 @@ using UnityEngine.UI;
 namespace QSB.Tools.TranslatorTool;
 
 [UsedInUnityProject]
-internal class QSBNomaiTranslatorProp : MonoBehaviour
+public class QSBNomaiTranslatorProp : MonoBehaviour
 {
 	private static MaterialPropertyBlock s_matPropBlock;
 	private static int s_propID_EmissionColor;

--- a/QSB/Tools/TranslatorTool/QSBTranslatorScanBeam.cs
+++ b/QSB/Tools/TranslatorTool/QSBTranslatorScanBeam.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace QSB.Tools.TranslatorTool;
 
 [UsedInUnityProject]
-internal class QSBTranslatorScanBeam : MonoBehaviour
+public class QSBTranslatorScanBeam : MonoBehaviour
 {
 	public Renderer _projectorRenderer;
 	public Renderer _lightVolumeRenderer;

--- a/QSB/Tools/TranslatorTool/TranslationSync/Messages/SetAsTranslatedMessage.cs
+++ b/QSB/Tools/TranslatorTool/TranslationSync/Messages/SetAsTranslatedMessage.cs
@@ -3,7 +3,7 @@ using QSB.Tools.TranslatorTool.TranslationSync.WorldObjects;
 
 namespace QSB.Tools.TranslatorTool.TranslationSync.Messages;
 
-internal class SetAsTranslatedMessage : QSBWorldObjectMessage<QSBNomaiText, int>
+public class SetAsTranslatedMessage : QSBWorldObjectMessage<QSBNomaiText, int>
 {
 	public SetAsTranslatedMessage(int textId) : base(textId) { }
 

--- a/QSB/Tools/TranslatorTool/TranslationSync/Patches/SpiralPatches.cs
+++ b/QSB/Tools/TranslatorTool/TranslationSync/Patches/SpiralPatches.cs
@@ -7,7 +7,7 @@ using QSB.WorldSync;
 
 namespace QSB.Tools.TranslatorTool.TranslationSync.Patches;
 
-internal class SpiralPatches : QSBPatch
+public class SpiralPatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/Tools/TranslatorTool/TranslationSync/SpiralManager.cs
+++ b/QSB/Tools/TranslatorTool/TranslationSync/SpiralManager.cs
@@ -5,7 +5,7 @@ using System.Threading;
 
 namespace QSB.Tools.TranslatorTool.TranslationSync;
 
-internal class SpiralManager : WorldObjectManager
+public class SpiralManager : WorldObjectManager
 {
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.Both;
 

--- a/QSB/Tools/TranslatorTool/TranslationSync/WorldObjects/QSBNomaiText.cs
+++ b/QSB/Tools/TranslatorTool/TranslationSync/WorldObjects/QSBNomaiText.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace QSB.Tools.TranslatorTool.TranslationSync.WorldObjects;
 
-internal class QSBNomaiText : WorldObject<NomaiText>
+public class QSBNomaiText : WorldObject<NomaiText>
 {
 	public override void SendInitialState(uint to) =>
 		GetTranslatedIds().ForEach(id =>

--- a/QSB/Tools/TranslatorTool/TranslatorCreator.cs
+++ b/QSB/Tools/TranslatorTool/TranslatorCreator.cs
@@ -2,7 +2,7 @@
 
 namespace QSB.Tools.TranslatorTool;
 
-internal static class TranslatorCreator
+public static class TranslatorCreator
 {
 	internal static void CreateTranslator(PlayerInfo player)
 	{

--- a/QSB/Utility/CustomRelativisticParticleSystem.cs
+++ b/QSB/Utility/CustomRelativisticParticleSystem.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace QSB.Utility;
 
 [UsedInUnityProject]
-internal class CustomRelativisticParticleSystem : MonoBehaviour
+public class CustomRelativisticParticleSystem : MonoBehaviour
 {
 	private ParticleSystem _particleSystem;
 	private Transform _simulationSpace;

--- a/QSB/Utility/DebugCameraSettings.cs
+++ b/QSB/Utility/DebugCameraSettings.cs
@@ -2,7 +2,7 @@
 
 namespace QSB.Utility;
 
-internal class DebugCameraSettings : MonoBehaviour, IAddComponentOnStart
+public class DebugCameraSettings : MonoBehaviour, IAddComponentOnStart
 {
 	public static void UpdateFromDebugSetting()
 	{

--- a/QSB/Utility/DebugGUI.cs
+++ b/QSB/Utility/DebugGUI.cs
@@ -15,7 +15,7 @@ using UnityEngine;
 
 namespace QSB.Utility;
 
-internal class DebugGUI : MonoBehaviour, IAddComponentOnStart
+public class DebugGUI : MonoBehaviour, IAddComponentOnStart
 {
 	private const float _debugLineSpacing = 8f;
 	private const float FixedWidth = 200f;

--- a/QSB/Utility/Popcron.Gizmos/Drawers/FrustumDrawer.cs
+++ b/QSB/Utility/Popcron.Gizmos/Drawers/FrustumDrawer.cs
@@ -2,7 +2,7 @@
 
 namespace Popcron
 {
-	internal class FrustumDrawer : Drawer
+	public class FrustumDrawer : Drawer
 	{
 		public FrustumDrawer()
 		{

--- a/QSB/Utility/Popcron.Gizmos/Element.cs
+++ b/QSB/Utility/Popcron.Gizmos/Element.cs
@@ -2,7 +2,7 @@
 
 namespace Popcron
 {
-	internal class Element
+	public class Element
 	{
 		public Vector3[] points = { };
 		public Color color = Color.white;

--- a/QSB/Utility/UIHelper.cs
+++ b/QSB/Utility/UIHelper.cs
@@ -2,7 +2,7 @@
 
 namespace QSB.Utility;
 
-internal static class UIHelper
+public static class UIHelper
 {
 	public static void ReplaceUI(UITextType key, string text)
 	{

--- a/QSB/WorldSync/MiscManager.cs
+++ b/QSB/WorldSync/MiscManager.cs
@@ -5,7 +5,7 @@ using System.Threading;
 
 namespace QSB.WorldSync;
 
-internal class MiscManager : WorldObjectManager
+public class MiscManager : WorldObjectManager
 {
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.Both;
 	public override bool DlcOnly => false;

--- a/QSB/WorldSync/QSBOWRigidbody.cs
+++ b/QSB/WorldSync/QSBOWRigidbody.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// todo make sure this isn't totally broken in weird esoteric cases oh god oh fuck
 /// </summary>
-internal class QSBOWRigidbody : WorldObject<OWRigidbody>
+public class QSBOWRigidbody : WorldObject<OWRigidbody>
 {
 	public override bool ShouldDisplayDebug() => false;
 }

--- a/QSB/WorldSync/WorldObjectsHashMessage.cs
+++ b/QSB/WorldSync/WorldObjectsHashMessage.cs
@@ -8,7 +8,7 @@ namespace QSB.WorldSync;
 /// <summary>
 /// sends QSBWorldSync.WorldObjectsHash to the server for sanity checking
 /// </summary>
-internal class WorldObjectsHashMessage : QSBMessage<(string managerName, string hash, int count)>
+public class WorldObjectsHashMessage : QSBMessage<(string managerName, string hash, int count)>
 {
 	public WorldObjectsHashMessage(string managerName, string hash, int count) : base((managerName, hash, count)) => To = 0;
 

--- a/QSB/ZeroGCaveSync/Messages/SatelliteNodeRepairTickMessage.cs
+++ b/QSB/ZeroGCaveSync/Messages/SatelliteNodeRepairTickMessage.cs
@@ -3,7 +3,7 @@ using QSB.ZeroGCaveSync.WorldObjects;
 
 namespace QSB.ZeroGCaveSync.Messages;
 
-internal class SatelliteNodeRepairTickMessage : QSBWorldObjectMessage<QSBSatelliteNode, float>
+public class SatelliteNodeRepairTickMessage : QSBWorldObjectMessage<QSBSatelliteNode, float>
 {
 	public SatelliteNodeRepairTickMessage(float repairFraction) : base(repairFraction) { }
 

--- a/QSB/ZeroGCaveSync/Messages/SatelliteNodeRepairedMessage.cs
+++ b/QSB/ZeroGCaveSync/Messages/SatelliteNodeRepairedMessage.cs
@@ -3,7 +3,7 @@ using QSB.ZeroGCaveSync.WorldObjects;
 
 namespace QSB.ZeroGCaveSync.Messages;
 
-internal class SatelliteNodeRepairedMessage : QSBWorldObjectMessage<QSBSatelliteNode>
+public class SatelliteNodeRepairedMessage : QSBWorldObjectMessage<QSBSatelliteNode>
 {
 	public override void OnReceiveRemote() => WorldObject.SetRepaired();
 }

--- a/QSB/ZeroGCaveSync/Patches/ZeroGCavePatches.cs
+++ b/QSB/ZeroGCaveSync/Patches/ZeroGCavePatches.cs
@@ -10,7 +10,7 @@ using UnityEngine;
 namespace QSB.ZeroGCaveSync.Patches;
 
 [HarmonyPatch]
-internal class ZeroGCavePatches : QSBPatch
+public class ZeroGCavePatches : QSBPatch
 {
 	public override QSBPatchTypes Type => QSBPatchTypes.OnClientConnect;
 

--- a/QSB/ZeroGCaveSync/WorldObjects/QSBSatelliteNode.cs
+++ b/QSB/ZeroGCaveSync/WorldObjects/QSBSatelliteNode.cs
@@ -5,7 +5,7 @@ using QSB.ZeroGCaveSync.Messages;
 
 namespace QSB.ZeroGCaveSync.WorldObjects;
 
-internal class QSBSatelliteNode : WorldObject<SatelliteNode>
+public class QSBSatelliteNode : WorldObject<SatelliteNode>
 {
 	public override void SendInitialState(uint to)
 	{

--- a/QSB/ZeroGCaveSync/ZeroGCaveManager.cs
+++ b/QSB/ZeroGCaveSync/ZeroGCaveManager.cs
@@ -5,7 +5,7 @@ using System.Threading;
 
 namespace QSB.ZeroGCaveSync;
 
-internal class ZeroGCaveManager : WorldObjectManager
+public class ZeroGCaveManager : WorldObjectManager
 {
 	public override WorldObjectScene WorldObjectScene => WorldObjectScene.SolarSystem;
 

--- a/QSB/manifest.json
+++ b/QSB/manifest.json
@@ -7,7 +7,7 @@
 		"body": "- Disable *all* other mods. (Can heavily affect performance)\n- Make sure you are not running any other network-intensive applications."
 	},
 	"uniqueName": "Raicuparta.QuantumSpaceBuddies",
-	"version": "0.29.2",
+	"version": "0.30.0",
 	"owmlVersion": "2.9.5",
 	"dependencies": [ "_nebula.MenuFramework", "JohnCorby.VanillaFix" ],
 	"pathsToPreserve": [ "debugsettings.json" ],

--- a/QSB/manifest.json
+++ b/QSB/manifest.json
@@ -8,7 +8,7 @@
 	},
 	"uniqueName": "Raicuparta.QuantumSpaceBuddies",
 	"version": "0.29.2",
-	"owmlVersion": "2.9.3",
+	"owmlVersion": "2.9.5",
 	"dependencies": [ "_nebula.MenuFramework", "JohnCorby.VanillaFix" ],
 	"pathsToPreserve": [ "debugsettings.json" ],
 	"requireLatestVersion": true

--- a/QSB/manifest.json
+++ b/QSB/manifest.json
@@ -7,7 +7,7 @@
 		"body": "- Disable *all* other mods. (Can heavily affect performance)\n- Make sure you are not running any other network-intensive applications."
 	},
 	"uniqueName": "Raicuparta.QuantumSpaceBuddies",
-	"version": "0.29.1",
+	"version": "0.29.2",
 	"owmlVersion": "2.9.3",
 	"dependencies": [ "_nebula.MenuFramework", "JohnCorby.VanillaFix" ],
 	"pathsToPreserve": [ "debugsettings.json" ],

--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -12,13 +12,13 @@ QSB can only be translated to the languages Outer Wilds supports - so if you don
 - German
 - Chinese (Simplified)
 - Spanish (Latin American)
+- Turkish
 
 ### Un-translated languages :
 - Italian
 - Polish
 - Japanese
 - Korean
-- Turkish
 
 ## Translating
 


### PR DESCRIPTION
- Implemented API
  - Can use PlayerInfo's CustomData methods from the API
  - Can send messages with custom data from the API
- Increased text chat character limit to 256
- Added method `QSBCore.RegisterNotRequiredForAllPlayers` for registering "cosmetic" addons (addons that don't send any networking data)
- Removed check for NH compatibility addon.
- Made every internal class public.
- Added API test mod.
- Update OWML version.
- Cleanup of DebugLog.